### PR TITLE
Tests Patch : Made them Sync by Await and added test for Flexible admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ These are the contracts for Razor network.
 2. Install openzeppelin
 `npm i openzeppelin-solidity`
 3. Run ganache-cli
-`ganache-cli -s 0 -i 420 -a 30`
+`ganache-cli -s 0 -i 420 -a 30 -l 7000000`
 4. Run tests
 `truffle test`
 5. For bigSchelling.js large number of accounts are required
-`ganache-cli -s 0 -i 420 -a 101`
+`ganache-cli -s 0 -i 420 -a 101 -l 7000000`
 6. For testing with cli, set blocktime
-`ganache-cli -s 0 -i 420 -a 30 -b 5`
+`ganache-cli -s 0 -i 420 -a 30 -b 5 -l 7000000`
 7. Deploy on ganache
 `truffle migrate --reset`
 8. create .secret file with mnemonic of the private key used to deploy on rinkeby

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -313,4 +313,23 @@ contract("Access Control Test", async accounts => {
         await stakeManager.updateCommitmentEpoch(1)
         stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
     });
+
+    it("Default Admin should able to change, New admin should able to grant/revoke", async () => {
+        let stakeManager = await StakeManager.deployed();
+        let constants = await Constants.deployed();
+        let DEFAULT_ADMIN_ROLE_HASH = "0x00";
+
+        // Old admin should be able to grant admin role to another account
+        stakeManager.grantRole(DEFAULT_ADMIN_ROLE_HASH, accounts[1]);
+
+        // New admin should be able to revoke admin access from old admin
+        stakeManager.revokeRole(DEFAULT_ADMIN_ROLE_HASH, accounts[0], { 'from': accounts[1] });
+
+        // Old admin should not able to assign roles anymore
+        await assertRevert(stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]));
+
+        // New admin should be able to assign roles
+        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0], { 'from': accounts[1] });
+
+    });
 });

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -41,30 +41,30 @@ contract("Access Control Test", async accounts => {
         await assertRevert(jobManager.fulfillJob(2, 222))
 
         // Checking if BlockConfirmer can access it
-        jobManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await jobManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(jobManager.fulfillJob(2, 222))
 
         // Checking if StakeModifier can access it
-        jobManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await jobManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await assertRevert(jobManager.fulfillJob(2, 222))
 
         // Checking if StakerActivityUpdater can access it
-        jobManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await jobManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await assertRevert(jobManager.fulfillJob(2, 222))
 
         // revoking is important to not impact other test cases
-        jobManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        jobManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
-        jobManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await jobManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await jobManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await jobManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
 
     });
 
     it("fulFillJob() should be accessable by only JobConfirmer", async () => {
         let jobManager = await JobManager.deployed();
         let constants = await Constants.deployed();
-        jobManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await jobManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await jobManager.fulfillJob(2, 222);
-        jobManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await jobManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
 
     });
 
@@ -76,30 +76,30 @@ contract("Access Control Test", async accounts => {
         await assertRevert(blockManager.confirmBlock());
 
         // Checking if JobConfirmer can access it
-        blockManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await blockManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(blockManager.confirmBlock())
 
         // Checking if StakeModifier can access it
-        blockManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await blockManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await assertRevert(blockManager.confirmBlock())
 
         // Checking if StakerActivityUpdater can access it
-        blockManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await blockManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await assertRevert(blockManager.confirmBlock())
 
 
-        blockManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        blockManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
-        blockManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await blockManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await blockManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await blockManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
 
     });
 
     it("confirmBlock() should be accessable by BlockConfirmer", async () => {
         let blockManager = await BlockManager.deployed();
         let constants = await Constants.deployed();
-        blockManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await blockManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await blockManager.confirmBlock()
-        blockManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await blockManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
     });
 
     it("slash() should not be accessable by anyone besides StakeModifier", async () => {
@@ -110,21 +110,21 @@ contract("Access Control Test", async accounts => {
         await assertRevert(stakeManager.slash(1, accounts[2], 1));
 
         // Checking if JobConfirmer can access it
-        stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.slash(1, accounts[2], 1))
 
         // Checking if BlockConfirmer can access it
-        stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.slash(1, accounts[2], 1))
 
         // Checking if StakerActivityUpdater can access it
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await assertRevert(stakeManager.slash(1, accounts[2], 1))
 
 
-        stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
 
     });
 
@@ -133,9 +133,9 @@ contract("Access Control Test", async accounts => {
         let constants = await Constants.deployed();
 
 
-        stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await stakeManager.slash(1, accounts[2], 1)
-        stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
     });
 
 
@@ -147,20 +147,20 @@ contract("Access Control Test", async accounts => {
         await assertRevert(stakeManager.giveBlockReward(1, 1));
 
         // Checking if JobConfirmer can access it
-        stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.giveBlockReward(1, 1))
 
         // Checking if BlockConfirmer can access it
-        stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.giveBlockReward(1, 1))
 
         // Checking if StakerActivityUpdater can access it
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await assertRevert(stakeManager.giveBlockReward(1, 1))
 
-        stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
 
     });
 
@@ -169,9 +169,9 @@ contract("Access Control Test", async accounts => {
         let constants = await Constants.deployed();
 
 
-        stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await stakeManager.giveBlockReward(1, 1)
-        stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
     });
 
     it("giveRewards() should not be accessable by anyone besides StakeModifier", async () => {
@@ -182,20 +182,20 @@ contract("Access Control Test", async accounts => {
         await assertRevert(stakeManager.giveRewards(1, 1));
 
         // Checking if JobConfirmer can access it
-        stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.giveRewards(1, 1))
 
         // Checking if BlockConfirmer can access it
-        stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.giveRewards(1, 1))
 
         // Checking if StakerActivityUpdater can access it
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await assertRevert(stakeManager.giveRewards(1, 1))
 
-        stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
 
     });
 
@@ -204,9 +204,9 @@ contract("Access Control Test", async accounts => {
         let constants = await Constants.deployed();
 
 
-        stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await stakeManager.giveRewards(1, 1)
-        stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
     });
 
     it("givePenalties() should not be accessable by anyone besides StakeModifier", async () => {
@@ -217,20 +217,20 @@ contract("Access Control Test", async accounts => {
         await assertRevert(stakeManager.givePenalties(1, 1));
 
         // Checking if JobConfirmer can access it
-        stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.givePenalties(1, 1))
 
         // Checking if BlockConfirmer can access it
-        stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.givePenalties(1, 1))
 
         // Checking if StakerActivityUpdater can access it
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await assertRevert(stakeManager.givePenalties(1, 1))
 
-        stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
 
     });
 
@@ -239,9 +239,9 @@ contract("Access Control Test", async accounts => {
         let constants = await Constants.deployed();
 
 
-        stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await stakeManager.givePenalties(1, 1)
-        stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
     });
 
     it("setStakerEpochLastRevealed() should not be accessable by anyone besides StakerActivityUpdater", async () => {
@@ -252,21 +252,21 @@ contract("Access Control Test", async accounts => {
         await assertRevert(stakeManager.setStakerEpochLastRevealed(1, 1));
 
         // Checking if JobConfirmer can access it
-        stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.setStakerEpochLastRevealed(1, 1))
 
         // Checking if BlockConfirmer can access it
-        stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.setStakerEpochLastRevealed(1, 1))
 
         // Checking if StakeModifier can access it
-        stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await assertRevert(stakeManager.setStakerEpochLastRevealed(1, 1))
 
 
-        stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
 
     });
 
@@ -275,9 +275,9 @@ contract("Access Control Test", async accounts => {
         let constants = await Constants.deployed();
 
 
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await stakeManager.setStakerEpochLastRevealed(1, 1)
-        stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
     });
 
     it("updateCommitmentEpoch() should not be accessable by anyone besides StakerActivityUpdater", async () => {
@@ -288,30 +288,30 @@ contract("Access Control Test", async accounts => {
         await assertRevert(stakeManager.updateCommitmentEpoch(1));
 
         // Checking if JobConfirmer can access it
-        stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getJobConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.updateCommitmentEpoch(1))
 
         // Checking if BlockConfirmer can access it
-        stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getBlockConfirmerHash(), accounts[0]);
         await assertRevert(stakeManager.updateCommitmentEpoch(1))
 
         // Checking if StakeModifier can access it
-        stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakeModifierHash(), accounts[0]);
         await assertRevert(stakeManager.updateCommitmentEpoch(1))
 
 
-        stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
-        stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getJobConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getBlockConfirmerHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakeModifierHash(), accounts[0]);
 
     });
 
     it("updateCommitmentEpoch() should be accessable by StakerActivityUpdater", async () => {
         let stakeManager = await StakeManager.deployed();
         let constants = await Constants.deployed();
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
         await stakeManager.updateCommitmentEpoch(1)
-        stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
+        await stakeManager.revokeRole(await constants.getStakerActivityUpdaterHash(), accounts[0]);
     });
 
     it("Default Admin should able to change, New admin should able to grant/revoke", async () => {
@@ -320,16 +320,16 @@ contract("Access Control Test", async accounts => {
         let DEFAULT_ADMIN_ROLE_HASH = "0x00";
 
         // Old admin should be able to grant admin role to another account
-        stakeManager.grantRole(DEFAULT_ADMIN_ROLE_HASH, accounts[1]);
+        await stakeManager.grantRole(DEFAULT_ADMIN_ROLE_HASH, accounts[1]);
 
         // New admin should be able to revoke admin access from old admin
-        stakeManager.revokeRole(DEFAULT_ADMIN_ROLE_HASH, accounts[0], { 'from': accounts[1] });
+        await stakeManager.revokeRole(DEFAULT_ADMIN_ROLE_HASH, accounts[0], { 'from': accounts[1] });
 
         // Old admin should not able to assign roles anymore
         await assertRevert(stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0]));
 
         // New admin should be able to assign roles
-        stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0], { 'from': accounts[1] });
+        await stakeManager.grantRole(await constants.getStakerActivityUpdaterHash(), accounts[0], { 'from': accounts[1] });
 
     });
 });

--- a/test/JobManager.js
+++ b/test/JobManager.js
@@ -68,7 +68,7 @@ contract('JobManager', function (accounts) {
       let repeat = true
       await jobManager.createJob(url, selector, name, repeat)
       console.log(Number(await jobManager.numJobs()))
-      jobManager.grantRole(await constants.getJobConfirmerHash(), accounts[0])
+      await jobManager.grantRole(await constants.getJobConfirmerHash(), accounts[0])
       await jobManager.fulfillJob(2, 222)
       // function fulfillJob(uint256 jobId, uint256 value) external onlyWriter {
 


### PR DESCRIPTION
**Tests written in ACL.js were inconsistent as they were async, made them sync by await
and added a new test case for Flexible Admin**

**Flexible Admin:** 👍 
The solution to Issue: To add the functionality of changing default admin in access control to ensure flexibility #39.
Openzeppelin Access control, already allows this functionality, so just needed to test if it's working properly in our case.
That's done now, its working fine.

Thanks!