### PR TITLE
Build as Sub Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ These are the contracts for Razor network.
 # Addresses
 Contract addresses can be found [here](ADDRESSES.md)
 
+# Guidelines for Collaborators
+
+- Build 
+   - We use [git-subrepo](https://github.com/ingydotnet/git-subrepo) for Build, as its common between multiple repos.
+   - The upstream can be found at [razor-network/build](https://github.com/razor-network/build)
+   - [Installation Instrusctions for git-subrepo](https://github.com/ingydotnet/git-subrepo#installation)
+   - To pull from upstream : (from parent repo)  git subrepo pull build
+   - To push to upstream : (from parent repo) git subrepo push build
+
+
+
+   

--- a/build/.gitrepo
+++ b/build/.gitrepo
@@ -1,0 +1,11 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = none
+	branch = master
+	commit = 
+	method = merge
+	cmdver = 0.4.3

--- a/build/.gitrepo
+++ b/build/.gitrepo
@@ -6,6 +6,7 @@
 [subrepo]
 	remote = https://github.com/razor-network/build.git
 	branch = master
-	commit = 
+	commit = 1098ed43b0d5099d8246a4261e9af23caf37d6ca
 	method = merge
 	cmdver = 0.4.3
+	parent = 39260c1909f39a41a911c04c664c698579244bae

--- a/build/.gitrepo
+++ b/build/.gitrepo
@@ -4,7 +4,7 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = none
+	remote = https://github.com/razor-network/build.git
 	branch = master
 	commit = 
 	method = merge


### PR DESCRIPTION
As Build is required between multiple repos, like cli, bridge.
It makes sense in making it as subrepo
As pointed out in https://github.com/razor-network/contracts/issues/35

Now to do that there are various options
1) Using Submodules or Subtress: Not used given added complexity for a end-user
2) Including push to dependent repos via CI : Not used as it increases CI exec time
3) Having build under .gitignore and manually updating it in respective dependent repos : It's true that build is something that does not change repeatedly, so having it in .gitignore makes sense there. But as some contracts are now in the development stage, this is not a good choice
4)  Using [git-subrepo](https://github.com/ingydotnet/git-subrepo) 🥇  This is the best option as it gets works done without any additional efforts needed for end-user

For contributors, its as simple as following  👍 
   - The upstream : [razor-network/build](https://github.com/razor-network/build)
   - [Installation Instrusctions](https://github.com/ingydotnet/git-subrepo#installation)
   - To pull from upstream : (from parent repo)  git subrepo pull build
   - To push to upstream : (from parent repo) git subrepo push build



