### PR TITLE
To Implement Block Reward Function | Halving

### DIFF
--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -166,6 +166,7 @@ contract StakeManager is Utils, ACL, StakeStorage {
         uint256 halvings = (block.number - genesisBlock) / Constants.halvingInterval();	
         if(halvings > lastHalvings) {
              lastBlockRewards = Constants.initialBlockReward() >>  halvings;
+             lastHalvings = halvings;
         }
 	    return lastBlockRewards	;		
     }

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -43,6 +43,8 @@ contract StakeManager is Utils, ACL, StakeStorage {
         voteManager = IVoteManager(_voteManagerAddress);
         blockManager = IBlockManager(_blockManagerAddress);
         stateManager = IStateManager(_stateManagerAddress);
+        genesisBlock = block.number;
+        lastBlockRewards = Constants.initialBlockReward();
     }
 
     event StakeChange(uint256 indexed stakerId, uint256 previousStake, uint256 newStake,
@@ -146,19 +148,35 @@ contract StakeManager is Utils, ACL, StakeStorage {
     /// called from confirmBlock function of BlockManager contract
     /// @param stakerId The ID of the staker
     function giveBlockReward(uint256 stakerId, uint256 epoch) external onlyRole(Constants.getStakeModifierHash()) {
-        if (Constants.blockReward() > 0) {
-            uint256 newStake = stakers[stakerId].stake.add(Constants.blockReward());
+        uint256 blockReward = _calculateBlockReward();
+        if (blockReward > 0) {
+            uint256 newStake = stakers[stakerId].stake.add(blockReward);
             _setStakerStake(stakerId, newStake, "Block Reward", epoch);
             // stakers[proposerId].stake = stakers[proposerId].stake.add(Constants.blockReward());
             // totalStake = totalStake.add(Constants.blockReward());
-            require(sch.mint(address(this), Constants.blockReward()));
+            require(sch.mint(address(this), blockReward));
         }
         uint256 prevStakeGettingReward = stakeGettingReward;
         stakeGettingReward = 0;
         emit StakeGettingRewardChange(epoch, prevStakeGettingReward, stakeGettingReward, now);
-
     }
 
+
+    event getBlockReward(
+        uint256 _genesisBlock,
+        uint256 _blockNumber,
+        uint256 _blockReward,
+        uint256 _halvings
+    );
+    function _calculateBlockReward() private returns(uint256)
+    {
+        uint256 halvings = (block.number - genesisBlock) / Constants.halvingInterval();	
+        if(halvings > lastHalvings) {
+             lastBlockRewards = Constants.initialBlockReward() >>  halvings;
+        }
+        emit getBlockReward(genesisBlock, block.number, lastBlockRewards, halvings);
+	    return lastBlockRewards	;		
+    }
     /// @notice This function is called in VoteManager reveal function to give
     /// rewards to all the stakers who have correctly staked, committed, revealed
     /// the Values of assets according to the razor protocol rules.
@@ -350,20 +368,5 @@ contract StakeManager is Utils, ACL, StakeStorage {
             }
         }
     }
-
-    // function stakeTransfer(uint256 fromId, address to, uint256 amount) internal{
-    //     // uint256 fromId = stakerIds[from];
-    //     require(fromId!=0);
-    //     require(stakers[fromId].stake >= amount);
-    //     uint256 toId = stakerIds[to];
-    //     stakers[fromId].stake = stakers[fromId].stake - amount;
-    //     if (toId == 0) {
-    //         numStakers = numStakers + 1;
-    //         stakers[numStakers] = Structs.Staker(numStakers, amount, 0, 0, 0);
-    //         stakerIds[to] = numStakers;
-    //     } else {
-    //         stakers[toId].stake = stakers[toId].stake + amount;
-    //     }
-    // }
 
 }

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -161,20 +161,12 @@ contract StakeManager is Utils, ACL, StakeStorage {
         emit StakeGettingRewardChange(epoch, prevStakeGettingReward, stakeGettingReward, now);
     }
 
-
-    event getBlockReward(
-        uint256 _genesisBlock,
-        uint256 _blockNumber,
-        uint256 _blockReward,
-        uint256 _halvings
-    );
     function _calculateBlockReward() private returns(uint256)
     {
         uint256 halvings = (block.number - genesisBlock) / Constants.halvingInterval();	
         if(halvings > lastHalvings) {
              lastBlockRewards = Constants.initialBlockReward() >>  halvings;
         }
-        emit getBlockReward(genesisBlock, block.number, lastBlockRewards, halvings);
 	    return lastBlockRewards	;		
     }
     /// @notice This function is called in VoteManager reveal function to give

--- a/contracts/Core/StakeStorage.sol
+++ b/contracts/Core/StakeStorage.sol
@@ -4,6 +4,10 @@ import "../lib/Structs.sol";
 
 contract StakeStorage {
 
+    uint256 public genesisBlock;
+    uint256 public lastHalvings;
+    uint256 public lastBlockRewards;
+
     // Constants public constants;
     mapping (address => uint256) public stakerIds;
     mapping (uint256 => Structs.Staker) public stakers;
@@ -11,6 +15,4 @@ contract StakeStorage {
     // SchellingCoin public sch;
     uint256 public rewardPool = 0;
     uint256 public stakeGettingReward = 0;
-
-       // uint256 public totalStake = 0;
 }

--- a/contracts/lib/Constants.sol
+++ b/contracts/lib/Constants.sol
@@ -12,7 +12,6 @@ library Constants {
     // uint256 constant PENALTY_NOT_IN_ZONE_NUM = 99;
     // uint256 constant PENALTY_NOT_IN_ZONE_DENOM = 100;
     function minStake() public pure returns(uint256) { return(100*(10**uint256(18))); }
-    function blockReward() public pure returns(uint256) { return(40*(10**uint256(18)));}
     // uint256 constant REVEAL_REWARD = 5;
     // function safetyMarginLower() public pure returns(uint256) { return(99); }
     function unstakeLockPeriod() public pure returns(uint256) { return(1); }
@@ -26,5 +25,12 @@ library Constants {
     function getBlockConfirmerHash() public pure returns(bytes32) { return(0x18797bc7973e1dadee1895be2f1003818e30eae3b0e7a01eb9b2e66f3ea2771f);/*keccak256("BLOCK_CONFIRMER_ROLE"))*/}
     function getStakeModifierHash() public pure returns(bytes32) { return(0xdbaaaff2c3744aa215ebd99971829e1c1b728703a0bf252f96685d29011fc804);/*keccak256("STAKE_MODIFIER_ROLE"))*/}
     function getStakerActivityUpdaterHash() public pure returns(bytes32) { return(0x4cd3070aaa07d03ab33731cbabd0cb27eb9e074a9430ad006c96941d71b77ece); /*keccak256("STAKER_ACTIVITY_UPDATER_ROLE"))*/}
+ 
+    // Constants Concerned With BlockReward
+    // Please note we have to change this values as per tokenomics, they are now added just to have have blockreward function running
+    // We need constants such that we reach total mintable supply on summation
+    function initialBlockReward() public pure returns(uint256) { return(100*(10**uint256(18)));}
+    function halvingInterval() public pure returns(uint256) { return(10000000);}
+
  // Constants(0, 1, 2, 3, 1, 10000, 99, 100, 1000, 5, 5, 99, 1, 1);
 }

--- a/test/BlockReward.js
+++ b/test/BlockReward.js
@@ -25,7 +25,7 @@ let StakeManager = artifacts.require('./StakeManager.sol')
 //     uint256 _halvings
 // );
 
-// And emit it in _calcualteBlockRewards()
+// And emit it in _calcualteBlockRewards()   :: emit getBlockReward(genesisBlock, block.number, lastBlockRewards, halvings);
 
 // Thats all you have to do
 

--- a/test/BlockReward.js
+++ b/test/BlockReward.js
@@ -1,0 +1,55 @@
+let functions = require('./helpers/functions')
+let StakeManager = artifacts.require('./StakeManager.sol')
+
+// By Default we skip this test as it takes very long time to pass with current defaults.
+// So now if we want to test this we can do so by doing follwoing changes and then you can remove skip
+
+// 1) To run this simulation one would have to change visibilty of _calculateBlockReward() to public 
+
+// 2) 
+// With Current Constants It would take long time to reach blockReward 0
+// So Please update constants in Constants.sol to lower numbers
+// Something Like this
+// function initialBlockReward() public pure returns(uint256) { return(100*(10**uint256(18)));}
+// function halvingInterval() public pure returns(uint256) { return(2);}
+
+// 3) 
+// As _CalculateBlockReward is non_view on return we reive tx receipt
+// Hence we will have to getvalues by events
+// Please define this event
+
+// event getBlockReward(
+//     uint256 _genesisBlock,
+//     uint256 _blockNumber,
+//     uint256 _blockReward,
+//     uint256 _halvings
+// );
+
+// And emit it in _calcualteBlockRewards()
+
+// Thats all you have to do
+
+contract.skip('Block Reward Test', function (accounts) {
+
+    it('Stimulate BlockRewardFunction and It Should not Overflow', async function () {
+        let stakeManager = await StakeManager.deployed()
+        let data = [];
+        var i = 0;
+        while (i < 3) {
+            try {
+                let txreceipt = await stakeManager._calculateBlockReward();
+                let args = txreceipt.logs[0].args;
+                data.push({ 'Genesis Block': Number(args['0']), 'No': Number(args['1']), 'BlockReward': Number(args['2']), 'Halvings': Number(args['3']) });
+                if (Number(args['2']) == 0) i++;
+                console.log(data[data.length - 1]);
+                await functions.waitNBlocks(0);
+            } catch (error) {
+                console.log("Take Care :" + error);
+            }
+
+        }
+        let verify = data[data.length - 1].BlockReward;
+        assert(verify === 0)
+    })
+
+})

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -36,21 +36,21 @@ contract('VoteManager', function (accounts) {
       // await stateManager.setEpoch(1)
       // await stateManager.setState(0)
       await functions.mineToNextEpoch()
-      await sch.transfer(accounts[3], new BN(423000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[0]})
-      await sch.transfer(accounts[4], new BN(19000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[0]})
-      await sch.approve(stakeManager.address, new BN(420000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[3]})
-      await sch.approve(stakeManager.address, new BN(19000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[4]})
+      await sch.transfer(accounts[3], new BN(423000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[0] })
+      await sch.transfer(accounts[4], new BN(19000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[0] })
+      await sch.approve(stakeManager.address, new BN(420000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[3] })
+      await sch.approve(stakeManager.address, new BN(19000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[4] })
       let epoch = await functions.getEpoch()
-      await stakeManager.stake(epoch, new BN(420000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[3]})
-      await stakeManager.stake(epoch, new BN(19000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[4]})
-    // await sch.transfer(accounts[3], 800000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[4], 600000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[5], 2000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[6], 700000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[7], 3000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[8], 4000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[9], 5000, { 'from': accounts[0]})
-    // await sch.transfer(accounts[10], 6000, { 'from': accounts[0]})
+      await stakeManager.stake(epoch, new BN(420000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[3] })
+      await stakeManager.stake(epoch, new BN(19000).mul(new BN(10).pow(new BN('18'))), { 'from': accounts[4] })
+      // await sch.transfer(accounts[3], 800000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[4], 600000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[5], 2000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[6], 700000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[7], 3000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[8], 4000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[9], 5000, { 'from': accounts[0]})
+      // await sch.transfer(accounts[10], 6000, { 'from': accounts[0]})
     })
 
     it('should be able to commit', async function () {
@@ -63,7 +63,7 @@ contract('VoteManager', function (accounts) {
       let root = tree.root()
       let commitment1 = web3i.utils.soliditySha3(epoch, root, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
 
-      await voteManager.commit(epoch, commitment1, { 'from': accounts[3]})
+      await voteManager.commit(epoch, commitment1, { 'from': accounts[3] })
       // arguments getCommitment => epoch number and stakerId
       let stakerId_acc3 = await stakeManager.stakerIds(accounts[3])
       let commitment2 = await voteManager.getCommitment(epoch, stakerId_acc3)
@@ -74,7 +74,7 @@ contract('VoteManager', function (accounts) {
       let tree2 = merkle('keccak256').sync(votes2)
       let root2 = tree2.root()
       let commitment3 = web3i.utils.soliditySha3(epoch, root2, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
-      await voteManager.commit(epoch, commitment3, { 'from': accounts[4]})
+      await voteManager.commit(epoch, commitment3, { 'from': accounts[4] })
     })
 
     it('should be able to reveal', async function () {
@@ -101,7 +101,7 @@ contract('VoteManager', function (accounts) {
 
       await voteManager.reveal(epoch, tree.root(), votes, proof,
         '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
-        accounts[3], { 'from': accounts[3]})
+        accounts[3], { 'from': accounts[3] })
       // arguments getvVote => epoch, stakerId, assetId
       assert(Number((await voteManager.getVote(epoch, stakerId_acc3, 0)).value) === 100, 'Vote not equal to 100')
 
@@ -114,10 +114,10 @@ contract('VoteManager', function (accounts) {
       }
       await voteManager.reveal(epoch, root2, votes2, proof2,
         '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
-        accounts[4], { 'from': accounts[4]})
+        accounts[4], { 'from': accounts[4] })
 
       let stakeAfter = Number((await stakeManager.stakers(stakerId_acc3)).stake)
-      console.log(stakeBefore , stakeAfter)
+      console.log(stakeBefore, stakeAfter)
       assert(stakeBefore === stakeAfter)
     })
 
@@ -150,7 +150,7 @@ contract('VoteManager', function (accounts) {
         [104, 204, 304, 404, 504, 604, 704, 804, 904],
         iteration,
         biggestStakerId,
-        { from: accounts[3]})
+        { from: accounts[3] })
 
       let stakeBefore = Number((await stakeManager.stakers(stakerId_acc3)).stake)
       let stakeBefore2 = Number((await stakeManager.stakers(stakerId_acc4)).stake)
@@ -162,13 +162,13 @@ contract('VoteManager', function (accounts) {
       let root = tree.root()
       let commitment1 = web3i.utils.soliditySha3(epoch, root, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
 
-      await voteManager.commit(epoch, commitment1, { 'from': accounts[3]})
+      await voteManager.commit(epoch, commitment1, { 'from': accounts[3] })
 
       let votes2 = [104, 204, 304, 404, 504, 604, 704, 804, 904]
       let tree2 = merkle('keccak256').sync(votes2)
       let root2 = tree2.root()
       let commitment2 = web3i.utils.soliditySha3(epoch, root2, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
-      await voteManager.commit(epoch, commitment2, { 'from': accounts[4]})
+      await voteManager.commit(epoch, commitment2, { 'from': accounts[4] })
       // arguments getCommitment => epoch number and stakerId
       let commitment3 = await voteManager.getCommitment(epoch, stakerId_acc3)
       // let commitment2 = await voteManager.getCommitment(epoch, stakerId_acc3)
@@ -177,15 +177,15 @@ contract('VoteManager', function (accounts) {
 
       let stakeAfter = ((await stakeManager.stakers(stakerId_acc3)).stake)
       let stakeAfter2 = ((await stakeManager.stakers(stakerId_acc4)).stake)
-      assert(stakeBefore + Number(new BN(40).mul(new BN(10).pow(new BN('18')))) === Number(stakeAfter), 'Not rewarded')
+      assert(stakeBefore < Number(stakeAfter), 'Not rewarded')
       assert(stakeBefore2 === Number(stakeAfter2), 'Penalty should not be applied')
       let stakeGettingReward = Number(await stakeManager.stakeGettingReward())
       assert(stakeGettingReward === Number(stakeAfter2.add(stakeAfter)), 'Error 3')
-    // let votes2 = [104, 204, 304, 404, 504, 604, 704, 804, 904]
-    // let tree2 = merkle('keccak256').sync(votes2)
-    // let root2 = tree2.root()
-    // let commitment3 = web3i.utils.soliditySha3(epoch, root2, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
-    // await voteManager.commit(epoch, commitment3, { 'from': accounts[4]})
+      // let votes2 = [104, 204, 304, 404, 504, 604, 704, 804, 904]
+      // let tree2 = merkle('keccak256').sync(votes2)
+      // let root2 = tree2.root()
+      // let commitment3 = web3i.utils.soliditySha3(epoch, root2, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
+      // await voteManager.commit(epoch, commitment3, { 'from': accounts[4]})
     })
 
     it('should be able to reveal again but with no rewards for now', async function () {
@@ -221,29 +221,29 @@ contract('VoteManager', function (accounts) {
       }
 
       await functions.mineToNextState() // reveal
-      
-      
+
+
       await voteManager.reveal(epoch, tree.root(), votes, proof,
         '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
-        accounts[3], { from: accounts[3]})
+        accounts[3], { from: accounts[3] })
       // arguments getvVote => epoch, stakerId, assetId
       assert(Number((await voteManager.getVote(epoch, stakerId_acc3, 0)).value) === 100, 'Vote not equal to 100')
 
       await voteManager.reveal(epoch, tree2.root(), votes2, proof2,
         '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
-        accounts[4], { from: accounts[4]})
+        accounts[4], { from: accounts[4] })
 
       let rewardPool = Number(await stakeManager.rewardPool())
       let stakeAfter = Number((await stakeManager.stakers(stakerId_acc3)).stake)
       let stakeAfter2 = Number((await stakeManager.stakers(stakerId_acc4)).stake)
       console.log('stake should have recieved rewardpool', stakeBefore + rewardPool, stakeAfter)
-      console.log(stakeBefore2 , stakeAfter2)
+      console.log(stakeBefore2, stakeAfter2)
       assert(rewardPool === 0)
       assert(stakeBefore === stakeAfter)
       assert(stakeBefore2 === stakeAfter2)
     })
 
-    it('account 4 should be penalised for trying to make fraudulent predictions in the previous epoch', async function(){
+    it('account 4 should be penalised for trying to make fraudulent predictions in the previous epoch', async function () {
       let stakeManager = await StakeManager.deployed()
       let voteManager = await VoteManager.deployed()
       let blockManager = await BlockManager.deployed()
@@ -272,7 +272,7 @@ contract('VoteManager', function (accounts) {
         [103, 203, 303, 403, 503, 603, 703, 803, 903],
         iteration,
         biggestStakerId,
-        { from: accounts[3]})
+        { from: accounts[3] })
 
       let stakeBefore = ((await stakeManager.stakers(stakerId_acc3)).stake)
       let stakeBefore2 = ((await stakeManager.stakers(stakerId_acc4)).stake)
@@ -284,8 +284,8 @@ contract('VoteManager', function (accounts) {
       let root = tree.root()
       let commitment1 = web3i.utils.soliditySha3(epoch, root, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd')
 
-      await voteManager.commit(epoch, commitment1, { 'from': accounts[3]})
-      await voteManager.commit(epoch, commitment1, { 'from': accounts[4]})
+      await voteManager.commit(epoch, commitment1, { 'from': accounts[3] })
+      await voteManager.commit(epoch, commitment1, { 'from': accounts[4] })
 
       let commitment2 = await voteManager.getCommitment(epoch, stakerId_acc3)
 
@@ -301,8 +301,8 @@ contract('VoteManager', function (accounts) {
       }
 
       console.log(Number(stakeBefore2.sub(penalty)), Number(stakeAfter2))
-      assert(Number(stakeBefore.add(new BN(40).mul(new BN(10).pow(new BN('18'))))) === Number(stakeAfter), 'Not rewarded')
-      assert(Number(stakeBefore2.sub(penalty))  === Number(stakeAfter2), 'Penalty should be applied')
+      assert(Number(stakeBefore) < Number(stakeAfter), 'Not rewarded')
+      assert(Number(stakeBefore2.sub(penalty)) === Number(stakeAfter2), 'Penalty should be applied')
       let stakeGettingReward = Number(await stakeManager.stakeGettingReward())
       console.log(stakeGettingReward, Number(stakeAfter))
       assert(stakeGettingReward === Number(stakeAfter), 'Error 3')
@@ -310,7 +310,7 @@ contract('VoteManager', function (accounts) {
       assert(rewardPool === Number(penalty), 'reward pool should not be zero as penalties have been applied')
     })
 
-    it('Account 4 should have his stake slashed for leaking out his secret to another account before the reveal state', async function(){
+    it('Account 4 should have his stake slashed for leaking out his secret to another account before the reveal state', async function () {
       let stakeManager = await StakeManager.deployed()
       let voteManager = await VoteManager.deployed()
       let sch = await SchellingCoin.deployed()
@@ -328,22 +328,22 @@ contract('VoteManager', function (accounts) {
 
       await voteManager.reveal(epoch, tree.root(), votes, proof,
         '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
-        accounts[4], { from: accounts[10]})
+        accounts[4], { from: accounts[10] })
 
       let stakeAfter = Number((await stakeManager.stakers(stakerId_acc4)).stake)
-      let stake_acc10 = Number(await sch.balanceOf(accounts[10],{'from':accounts[10]}))
+      let stake_acc10 = Number(await sch.balanceOf(accounts[10], { 'from': accounts[10] }))
       console.log(stakeBefore, stakeAfter)
-      console.log(stake_acc10,(stakeBefore/2))
-      assert(stakeAfter===0, 'stake should be zero')
-      assert(stake_acc10===(stakeBefore/2), 'the bounty hunter should receive half of the stake of account 4')
+      console.log(stake_acc10, (stakeBefore / 2))
+      assert(stakeAfter === 0, 'stake should be zero')
+      assert(stake_acc10 === (stakeBefore / 2), 'the bounty hunter should receive half of the stake of account 4')
     })
 
-    it('Account 3 should be able to reveal again with correct rewards', async function (){
+    it('Account 3 should be able to reveal again with correct rewards', async function () {
       let stakeManager = await StakeManager.deployed()
       let voteManager = await VoteManager.deployed()
       let epoch = await functions.getEpoch()
       let stakerId_acc3 = await stakeManager.stakerIds(accounts[3])
-      
+
 
       let stakeBefore = Number((await stakeManager.stakers(stakerId_acc3)).stake)
 
@@ -364,7 +364,7 @@ contract('VoteManager', function (accounts) {
 
       await voteManager.reveal(epoch, tree.root(), votes, proof,
         '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
-        accounts[3], { from: accounts[3]})
+        accounts[3], { from: accounts[3] })
       // arguments getvVote => epoch, stakerId, assetId
       assert(Number((await voteManager.getVote(epoch, stakerId_acc3, 0)).value) === 100, 'Vote not equal to 100')
 


### PR DESCRIPTION
Hi All,
As pointed out in https://github.com/razor-network/contracts/issues/66 we needed a decreasing block reward function.
The same has been implemented in this PR.

We have used the standard halving function.
Where we halve block reward after a specific interval (measured in no of blocks)
```
  function _calculateBlockReward() private returns(uint256)
    {
        uint256 halvings = (block.number - genesisBlock) / Constants.halvingInterval();	
        if(halvings > lastHalvings) {
             lastBlockRewards = Constants.initialBlockReward() >>  halvings;
             lastHalvings = halvings;
        }
	    return lastBlockRewards	;		
    }
   
   ```
   **Please note that we will have to tune these constants (halvingInterval and Initial Block Rewards) as per tokenomics and deployment chain.**
   
   As of now, I have kept _calculateBlockReward() as private but I don't think visibility makes any difference here. 
   So kept Private just to be extra secure :)
   
  The new test has been added to test this functionality "BlockReward.js"
  It's skipped by default as it takes a very long time to pass with current defaults.
  _It takes long time as we have to mine blocks till we reach block reward 0, to check overflow conditions_
  (All details are mentioned in the source file)
  
  Please let me know if this is right approach 
  
  Thanks 👍 
 
  