### PR TITLE
solved compilation warnings

### DIFF
--- a/contracts/Core/ACL.sol
+++ b/contracts/Core/ACL.sol
@@ -3,7 +3,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "../lib/Constants.sol";
 
 contract ACL is AccessControl {
-    constructor() public {
+    constructor()  {
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
     modifier onlyRole(bytes32 _hash) {

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -322,7 +322,7 @@ contract StakeManager is Utils, ACL, StakeStorage {
 
         uint256[] memory lowerCutoffsLastEpoch = _block.lowerCutoffs;
         uint256[] memory higherCutoffsLastEpoch = _block.higherCutoffs;
-        uint256[] memory mediansLastEpoch = _block.medians;
+        
 
         if (lowerCutoffsLastEpoch.length > 0) {
             uint256 penalty = 0;
@@ -330,7 +330,7 @@ contract StakeManager is Utils, ACL, StakeStorage {
                 uint256 voteLastEpoch = voteManager.getVote(epochLastRevealed, thisStaker.id, i).value;
                 uint256 lowerCutoffLastEpoch = lowerCutoffsLastEpoch[i];
                 uint256 higherCutoffLastEpoch = higherCutoffsLastEpoch[i];
-                uint256 medianLastEpoch = mediansLastEpoch[i];
+                
 
                 if (((voteLastEpoch < lowerCutoffLastEpoch) ||
                     (voteLastEpoch > higherCutoffLastEpoch))) {//} &&

--- a/contracts/SchellingCoin.sol
+++ b/contracts/SchellingCoin.sol
@@ -18,7 +18,7 @@ contract SchellingCoin is ERC20, AccessControl {
     /**
      * @dev Constructor that gives msg.sender all of existing tokens.
      */
-    constructor (address minter) public ERC20("SchellingCoin", "SCH") {
+    constructor (address minter)  ERC20("SchellingCoin", "SCH") {
         _mint(msg.sender, INITIAL_SUPPLY);
         _setupRole(MINTER_ROLE, minter);
     }


### PR DESCRIPTION
Some compilation warnings were there. I removed the public keyword from ACL.sol and SchellingCoin.sol. In version 0.8.0 compiler it was showing that the visibility of constructors are ignored. Also I removed the unused constants from StakeManager.sol