### PR TITLE
inheriting ACL contract in SchellingCoin contract, refactored few tests

### DIFF
--- a/contracts/SchellingCoin.sol
+++ b/contracts/SchellingCoin.sol
@@ -11,7 +11,7 @@ import "./Core/ACL.sol";
  * `ERC20` functions.
  */
 
-contract SchellingCoin is ERC20, AccessControl {
+contract SchellingCoin is ERC20, ACL {
 
     uint256 public constant DECIMALS = 18;
     //50 million supply. rest should be mintable

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -29,6 +29,11 @@ describe('Access Control Test', async () => {
     await restoreSnapshot(snapShotId);
   });
 
+  it('admin role should be granted', async () => {
+    const isAdminRoleGranted = await blockManager.hasRole(DEFAULT_ADMIN_ROLE_HASH, signers[0].address);
+    assert(isAdminRoleGranted === true, "Admin role was not Granted");
+  });
+
   it('fulFillJob() should not be accessable by anyone besides JobConfirmer', async () => {
     // Checking if Anyone can access it
     await assertRevert(jobManager.fulfillJob(2, 222), expectedRevertMessage);

--- a/test/BlockManager.js
+++ b/test/BlockManager.js
@@ -38,11 +38,12 @@ describe('BlockManager', function () {
   });
 
   describe('SchellingCoin', async () => {
-    it('Admin role should be granted',async () => {
 
-      assert(await blockManager.hasRole(DEFAULT_ADMIN_ROLE_HASH,signers[0].address)===true,"Role was not Granted")
-
+    it('admin role should be granted', async () => {
+      const isAdminRoleGranted = await blockManager.hasRole(DEFAULT_ADMIN_ROLE_HASH, signers[0].address);
+      assert(isAdminRoleGranted === true, "Admin role was not Granted");
     });
+
     it('should be able to initialize', async () => {
       await mineToNextEpoch();
       await schellingCoin.transfer(signers[5].address, tokenAmount('423000'));

--- a/test/JobManager.js
+++ b/test/JobManager.js
@@ -17,11 +17,12 @@ describe('JobManager', function () {
   });
 
   describe('Delegator', function () {
-    it('Admin role should be granted',async () => {
 
-      assert(await jobManager.hasRole(DEFAULT_ADMIN_ROLE_HASH,signers[0].address)===true,"Role was not Granted")
-
+    it('admin role should be granted', async () => {
+      const isAdminRoleGranted = await jobManager.hasRole(DEFAULT_ADMIN_ROLE_HASH, signers[0].address);
+      assert(isAdminRoleGranted === true, "Admin role was not Granted");
     });
+
     it('should be able to create Job', async function () {
       const url = 'http://testurl.com';
       const selector = 'selector';

--- a/test/SchellingCoin.js
+++ b/test/SchellingCoin.js
@@ -1,0 +1,17 @@
+const { DEFAULT_ADMIN_ROLE_HASH } = require('./helpers/constants');
+const { setupContracts } = require('./helpers/testSetup');
+  
+describe('SchellingCoin', function () {
+    let signers;
+
+    before(async () => {
+      ({ schellingCoin } = await setupContracts());
+      signers = await ethers.getSigners();
+    });
+
+
+    it('admin role should be granted', async () => {
+      const isAdminRoleGranted = await schellingCoin.hasRole(DEFAULT_ADMIN_ROLE_HASH, signers[0].address);
+      assert(isAdminRoleGranted === true, "Admin role was not Granted");
+    });
+});

--- a/test/StakeManager.js
+++ b/test/StakeManager.js
@@ -25,10 +25,10 @@ describe('StakeManager', function () {
       ({ schellingCoin, stakeManager, voteManager } = await setupContracts());
       signers = await ethers.getSigners();
     });
-    it('Admin role should be granted',async () => {
-
-      assert(await stakeManager.hasRole(DEFAULT_ADMIN_ROLE_HASH,signers[0].address)===true,"Role was not Granted")
-  
+    
+    it('admin role should be granted', async () => {
+      const isAdminRoleGranted = await stakeManager.hasRole(DEFAULT_ADMIN_ROLE_HASH, signers[0].address);
+      assert(isAdminRoleGranted === true, "Admin role was not Granted");
     });
 
     it('should be able to initialize', async function () {


### PR DESCRIPTION
Fix - inheriting ACL contract in SchellingCoin contract instead of OZ's AccessControl contract, refactored few tests.

This PR closes issue #111 