### PR TITLE
Fetching grace period from parameters and making its use readable

### DIFF
--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -19,7 +19,7 @@ contract Parameters is IParameters, ACL {
     uint256 public override epochLength = 300;
     uint256 public override numStates = 4;
     uint256 public override exposureDenominator = 1000;
-
+    uint256 public override gracePeriod = 8;
 
     uint32 constant private _COMMIT = 0;
     uint32 constant private _REVEAL = 1;
@@ -72,6 +72,10 @@ contract Parameters is IParameters, ACL {
 
     function setMinStake(uint256 _minStake) external onlyRole(DEFAULT_ADMIN_ROLE) { 
         minStake = _minStake;
+    }
+
+    function setGracePeriod(uint256 _gracePeriod) external onlyRole(DEFAULT_ADMIN_ROLE) { 
+        gracePeriod = _gracePeriod;
     }
 
     function getEpoch() external view override returns (uint256) {

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -370,7 +370,7 @@ contract StakeManager is Initializable, ACL, StakeStorage {
                                 thisStaker.epochLastRevealed :
                                 thisStaker.epochStaked;
         // penalize or reward if last active more than epoch - 1
-        uint256 inactiveEpochs = epoch-(epochLastActive)-1;
+        uint256 inactiveEpochs = (epoch-epochLastActive==0)?0:epoch-epochLastActive-1;
         uint256 previousStake = thisStaker.stake;
         // uint256 currentStake = previousStake;
         uint256 currentStake = calculateInactivityPenalties(inactiveEpochs, previousStake);

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -334,7 +334,7 @@ contract StakeManager is Initializable, ACL, StakeStorage {
     /// @notice Calculates the inactivity penalties of the staker
     /// @param epochs The difference of epochs where the staker was inactive
     /// @param stakeValue The Stake that staker had in last epoch
-    function calculateInactivityPenalties(uint256 epochs, uint256 stakeValue) public pure returns(uint256) {
+    function calculateInactivityPenalties(uint256 epochs, uint256 stakeValue) public view returns(uint256) {
         //If no of inactive epochs falls under grace period, do not penalise.
         if (epochs <= parameters.gracePeriod()) {
             return(stakeValue);

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -17,6 +17,7 @@ interface IParameters {
     function maxAltBlocks() external view returns(uint256);
     function epochLength() external view returns(uint256);
     function numStates() external view returns(uint256);
+    function gracePeriod() external view returns(uint256);
     function exposureDenominator() external view returns(uint256);
     function getEpoch() external view returns(uint256);
     function getState() external view returns(uint256);

--- a/test/Parameters.js
+++ b/test/Parameters.js
@@ -31,7 +31,7 @@ describe('Parameters contract Tests', async () => {
   const epochLength = toBigNumber('300');
   const totalStates = toBigNumber('4');
   const exposureDenominator = toBigNumber('1000');
-
+  const gracePeriod = toBigNumber('8');
   const minimumStake = tokenAmount('100');
 
   const blockConfirmerHash = utils.solidityKeccak256(['string'], ['BLOCK_CONFIRMER_ROLE']);
@@ -98,6 +98,9 @@ describe('Parameters contract Tests', async () => {
 
     tx = parameters.connect(signers[1]).setMinStake(toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
+
+    tx = parameters.connect(signers[1]).setGracePeriod(toBigNumber('1'));
+    await assertRevert(tx, expectedRevertMessage);
   });
 
   it('parameters should be able to modify with admin role access', async () => {
@@ -136,6 +139,11 @@ describe('Parameters contract Tests', async () => {
     await parameters.setExposureDenominator(toBigNumber('13'));
     const exposureDenominator = await parameters.exposureDenominator();
     assertBNEqual(exposureDenominator, toBigNumber('13'));
+
+    await parameters.setGracePeriod(toBigNumber('14'));
+    const gracePeriod = await parameters.gracePeriod();
+    assertBNEqual(gracePeriod, toBigNumber('14'));
+
   });
 
   it('parameters values should be initialized correctly', async () => {
@@ -192,5 +200,8 @@ describe('Parameters contract Tests', async () => {
 
     const stakeModifierHashValue = await parameters.getStakeModifierHash();
     assertBNEqual(stakeModifierHash, stakeModifierHashValue);
+
+    const gracePeriodValue = await parameters.gracePeriod();
+    assertBNEqual(gracePeriod, gracePeriodValue);
   });
 });

--- a/test/Parameters.js
+++ b/test/Parameters.js
@@ -143,7 +143,6 @@ describe('Parameters contract Tests', async () => {
     await parameters.setGracePeriod(toBigNumber('14'));
     const gracePeriod = await parameters.gracePeriod();
     assertBNEqual(gracePeriod, toBigNumber('14'));
-
   });
 
   it('parameters values should be initialized correctly', async () => {


### PR DESCRIPTION
Fixes https://github.com/razor-network/contracts/issues/104

Hi Guys,
This is small PR.
Firstly grace period is defined as constant and fetched from there so in the future we can expose it as a governance parameter.
Secondly 
rather than passing "Current Epoch - Last Active", 
now we are passing "Current Epoch - Last Active-1" to calculateInactivePenalties()
Which actually represent no of inactive epochs
Please refer to issue https://github.com/razor-network/contracts/issues/104 for more details

**Please note
This doesn't change any earlier behavior, as confirmed by tests as well.**

Rather than having
X < 10
first, we went 
X-1 < 9
then
X-1 <=8

That's all!

Here X is Current Epoch - Last Active

Signed-off-by: abhishekvispute <abhivispute33@gmail.com>