### PR TITLE
refactored_epoch_length_to_300

### DIFF
--- a/contracts/lib/Constants.sol
+++ b/contracts/lib/Constants.sol
@@ -14,7 +14,7 @@ library Constants {
     function unstakeLockPeriod() public pure returns(uint256) { return(1); }
     function withdrawLockPeriod() public pure returns(uint256) { return(1); }
     function maxAltBlocks() public pure returns(uint256) { return(5); }
-    function epochLength() public pure returns(uint256) { return(40); }
+    function epochLength() public pure returns(uint256) { return(300); }
     function numStates() public pure returns(uint256) { return(4); }
     function exposureDenominator() public pure returns(uint256) { return(1000); }
 

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -80,7 +80,7 @@ describe('Access Control Test', async () => {
 
   it('confirmBlock() should be accessable by BlockConfirmer', async () => {
     // Wait for 40 blocks, as epoch should be greated 40, for confirmBlock method to work.
-    await waitNBlocks(40);
+    await waitNBlocks(300);
     const blockConfirmerHash = await constants.getBlockConfirmerHash();
     await blockManager.grantRole(blockConfirmerHash, signers[0].address);
     await blockManager.confirmBlock();

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -3,10 +3,10 @@ const { BigNumber } = ethers;
 const DEFAULT_ADMIN_ROLE_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000';
 const ONE_ETHER = BigNumber.from(10).pow(BigNumber.from(18));
 
-const EPOCH_LENGTH = BigNumber.from(40);
+const EPOCH_LENGTH = BigNumber.from(300);
 const NUM_BLOCKS = 10;
 const NUM_STATES = BigNumber.from(4);
-const STATE_LENGTH = BigNumber.from(10);
+const STATE_LENGTH = BigNumber.from(75);
 const BLOCK_REWARD = BigNumber.from(40).mul(ONE_ETHER);
 const GRACE_PERIOD = 8;
 


### PR DESCRIPTION
The blocktime for goerli is 15 seconds whereas for matic it's 2 seconds. The current epoch length is set according to the goerli but this epoch length doesn't work for matic. It does not sync with the states due to which transactions are reverted


in order to match Matic and goerli block time, I have changed the epoch length to 300

Fixes #139 