### PR TITLE
Added restriction to Schelling Coin add Minter and Remove Minter

### DIFF
--- a/contracts/SchellingCoin.sol
+++ b/contracts/SchellingCoin.sol
@@ -24,17 +24,13 @@ contract SchellingCoin is ERC20, ACL {
      */
     constructor () ERC20("SchellingCoin", "SCH") {
         _mint(msg.sender, INITIAL_SUPPLY);
-        
-        
-    }
+   }
     
     function addMinter(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        
-        grantRole(MINTER_ROLE, account);
+                grantRole(MINTER_ROLE, account);
     }
 
-    function removeMinter(address account) external  onlyRole(DEFAULT_ADMIN_ROLE)  {
-        
+    function removeMinter(address account) external  onlyRole(DEFAULT_ADMIN_ROLE)  {        
         revokeRole(MINTER_ROLE, account);
     }
 

--- a/contracts/SchellingCoin.sol
+++ b/contracts/SchellingCoin.sol
@@ -18,19 +18,23 @@ contract SchellingCoin is ERC20, ACL {
     uint256 public constant INITIAL_SUPPLY = 1000000000 * (10 ** uint256(DECIMALS));
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     
+    
     /**
      * @dev Constructor that gives msg.sender all of existing tokens.
      */
     constructor () ERC20("SchellingCoin", "SCH") {
         _mint(msg.sender, INITIAL_SUPPLY);
         
+        
     }
     
-    function addMinter(address account) external {
+    function addMinter(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        
         grantRole(MINTER_ROLE, account);
     }
 
-    function removeMinter(address account) external {
+    function removeMinter(address account) external  onlyRole(DEFAULT_ADMIN_ROLE)  {
+        
         revokeRole(MINTER_ROLE, account);
     }
 

--- a/contracts/SchellingCoin.sol
+++ b/contracts/SchellingCoin.sol
@@ -27,7 +27,7 @@ contract SchellingCoin is ERC20, ACL {
    }
     
     function addMinter(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
-                grantRole(MINTER_ROLE, account);
+        grantRole(MINTER_ROLE, account);
     }
 
     function removeMinter(address account) external  onlyRole(DEFAULT_ADMIN_ROLE)  {        

--- a/test/SchellingCoin.js
+++ b/test/SchellingCoin.js
@@ -55,24 +55,20 @@ describe('SchellingCoin', function () {
     await assertRevert(tx, 'Caller is not a minter');
   });
 
-  it('should not be able to grant minter role', async() =>{
-    const tx = schellingCoin.connect(signers[1]).addMinter(signers[2].address)
-    await assertRevert(tx,'ACL: sender not authorized')
-
+  it('should not be able to grant minter role', async () => {
+    const tx = schellingCoin.connect(signers[1]).addMinter(signers[2].address);
+    await assertRevert(tx, 'ACL: sender not authorized');
   });
-  it('should be able to grant minter role', async() =>{
-    const tx = schellingCoin.connect(signers[0]).addMinter(signers[2].address)
-    await assert(tx,'ACL: Minter Role granted')
-
+  it('should be able to grant minter role', async () => {
+    const tx = schellingCoin.connect(signers[0]).addMinter(signers[2].address);
+    await assert(tx, 'ACL: Minter Role granted');
   });
-  it('should be able to Revoke minter role', async() =>{
-    const tx = schellingCoin.connect(signers[0]).removeMinter(signers[2].address)
-    await assert(tx,'ACL: Minter Role Revoked')
-
+  it('should be able to Revoke minter role', async () => {
+    const tx = schellingCoin.connect(signers[0]).removeMinter(signers[2].address);
+    await assert(tx, 'ACL: Minter Role Revoked');
   });
-  it('should not be able to revoke minter role', async() =>{
-    const tx = schellingCoin.connect(signers[1]).removeMinter(signers[2].address)
-    await assertRevert(tx,'ACL: sender not authorized')
-
+  it('should not be able to revoke minter role', async () => {
+    const tx = schellingCoin.connect(signers[1]).removeMinter(signers[2].address);
+    await assertRevert(tx, 'ACL: sender not authorized');
   });
 });

--- a/test/SchellingCoin.js
+++ b/test/SchellingCoin.js
@@ -54,4 +54,25 @@ describe('SchellingCoin', function () {
     const tx = schellingCoin.connect(signers[1]).mint(signers[3].address, tokenAmount('10'));
     await assertRevert(tx, 'Caller is not a minter');
   });
+
+  it('should not be able to grant minter role', async() =>{
+    const tx = schellingCoin.connect(signers[1]).addMinter(signers[2].address)
+    await assertRevert(tx,'ACL: sender not authorized')
+
+  });
+  it('should be able to grant minter role', async() =>{
+    const tx = schellingCoin.connect(signers[0]).addMinter(signers[2].address)
+    await assert(tx,'ACL: Minter Role granted')
+
+  });
+  it('should be able to Revoke minter role', async() =>{
+    const tx = schellingCoin.connect(signers[0]).removeMinter(signers[2].address)
+    await assert(tx,'ACL: Minter Role Revoked')
+
+  });
+  it('should not be able to revoke minter role', async() =>{
+    const tx = schellingCoin.connect(signers[1]).removeMinter(signers[2].address)
+    await assertRevert(tx,'ACL: sender not authorized')
+
+  });
 });


### PR DESCRIPTION
Currently anyone can become minter or remove itself as minter which might lead to some security issues. Hence in order to resolve this I have added a restriction that only owner can add the Minter and remove the minter.
resolves #140