### PR TITLE
made slashing penalty gov param 

### DIFF
--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -21,6 +21,7 @@ contract Parameters is IParameters, ACL {
     uint256 public override exposureDenominator = 1000;
     uint256 public override gracePeriod = 8;
     uint256 public override aggregationRange = 3;
+    uint256 public override percentSlashPenalty = 100;
 
     uint32 constant private _COMMIT = 0;
     uint32 constant private _REVEAL = 1;
@@ -81,6 +82,10 @@ contract Parameters is IParameters, ACL {
 
     function setAggregationRange(uint256 _aggregationRange) external onlyRole(DEFAULT_ADMIN_ROLE) {
         aggregationRange = _aggregationRange;
+    }
+    
+    function setpercentSlashPenalty(uint256 _percentSlashPenalty) external onlyRole(DEFAULT_ADMIN_ROLE){
+        percentSlashPenalty = _percentSlashPenalty;
     }
 
     function getEpoch() external view override returns (uint256) {

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -301,7 +301,7 @@ contract StakeManager is Initializable, ACL, StakeStorage {
         uint256 Stake =  stakers[id].stake - ((stakers[id].stake*parameters.percentSlashPenalty())/100);
         _setStakerStake(id, Stake , "Slashed", epoch);
         if (halfStake > 1) {
-        require(sch.transfer(bountyHunter, halfStake), "failed to transfer bounty");
+            require(sch.transfer(bountyHunter, halfStake), "failed to transfer bounty");
         }
     } 
 

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -297,10 +297,11 @@ contract StakeManager is Initializable, ACL, StakeStorage {
     /// @param id The ID of the staker who is penalised
     /// @param bountyHunter The address of the bounty hunter
     function slash (uint256 id, address bountyHunter, uint256 epoch) external onlyRole(parameters.getStakeModifierHash()) {
-        uint256 halfStake = stakers[id].stake/(2);
-        _setStakerStake(id, 0, "Slashed", epoch);
+        uint256 halfStake = ((stakers[id].stake)*(parameters.percentSlashPenalty()))/(2*100);
+        uint256 Stake =  stakers[id].stake - ((stakers[id].stake*parameters.percentSlashPenalty())/100);
+        _setStakerStake(id, Stake , "Slashed", epoch);
         if (halfStake > 1) {
-            require(sch.transfer(bountyHunter, halfStake), "failed to transfer bounty");
+        require(sch.transfer(bountyHunter, halfStake), "failed to transfer bounty");
         }
     } 
 

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -20,6 +20,7 @@ interface IParameters {
     function gracePeriod() external view returns(uint256);
     function aggregationRange() external view returns(uint256);
     function exposureDenominator() external view returns(uint256);
+    function percentSlashPenalty() external view returns(uint256);
     function getEpoch() external view returns(uint256);
     function getState() external view returns(uint256);
 


### PR DESCRIPTION
Fixes issue #152 
I have added a gov param as "percentSlashPenalty" by which we can decide and update how much percentage of the staker should be slashed and updated the slash function accordingly all tests have also passed. To remove linting errors commited one by one.

