### PR TITLE
resolved-todo for Parameters.sol

### DIFF
--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -6,7 +6,6 @@ import "./ACL.sol";
 
 contract Parameters is IParameters, ACL {
 
-    // TODO: Analyze what can be the maximum value (if needs to be reset) of these params.
     // constant type can be readjusted to some smaller type than uint256 for saving gas (storage variable packing).
     // penalty not reveal = 0.01% per epch
     uint256 public override penaltyNotRevealNum = 1;


### PR DESCRIPTION
there was a to-do comment on Parameters. sol to decide the Maximum Value of all the constants. But as per discussion, we do not need to have maximum values for constants. So I have removed that todo comment from Parameters.sol
fixes #172 