### PR TITLE
Changed RewardPool assginment as ternary condition.

### DIFF
--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -171,7 +171,7 @@ contract RewardManager is Initializable, ACL, RewardStorage {
                 );
                 uint256 newStake = thisStaker.stake + reward;
                 uint256 prevRewardPool = rewardPool;
-                rewardPool = rewardPool - (reward);
+                rewardPool = rewardPool >= reward ? rewardPool - reward : 0 ;
                 emit RewardPoolChange(
                     epoch,
                     prevRewardPool,

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -347,18 +347,18 @@ describe('VoteManager', function () {
         const stakeAfter = (await stakeManager.stakers(stakerIdAcc3)).stake;
         assertBNEqual(stakeBefore.add(rewardPool), stakeAfter);
       });
-      
-      it('Account 3 should not get rewards since lower cutOffs length of previous block was zero',async function(){
+
+      it('Account 3 should not get rewards since lower cutOffs length of previous block was zero', async function () {
         let epoch = await getEpoch();
         const stakerIdAcc3 = await stakeManager.stakerIds(signers[3].address);
         const staker = await stakeManager.getStaker(stakerIdAcc3);
-        const {biggestStakerId} = await getBiggestStakeAndId(stakeManager);
+        const { biggestStakerId } = await getBiggestStakeAndId(stakeManager);
         const iteration = await getIteration(stakeManager, random, staker);
-        await mineToNextState();//propose
-        await blockManager.connect(signers[3]).propose(epoch,[],[],[],[],iteration,biggestStakerId);
+        await mineToNextState();// propose
+        await blockManager.connect(signers[3]).propose(epoch, [], [], [], [], iteration, biggestStakerId);
 
-        await mineToNextState();//dispute
-        await mineToNextState();//commit
+        await mineToNextState();// dispute
+        await mineToNextState();// commit
 
         epoch = await getEpoch();
         const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
@@ -376,10 +376,11 @@ describe('VoteManager', function () {
           proof.push(tree.getProofPath(i, true, true));
         }
 
-        await mineToNextState(); //reveal
+        await mineToNextState(); // reveal
         await rewardManager.grantRole(await parameters.getRewardModifierHash(), signers[0].address);
         await rewardManager.incrementRewardPool(100);
-        await voteManager.connect(signers[3]).reveal(epoch, tree.root(),votes,proof,'0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',signers[3].address);
+        await voteManager.connect(signers[3])
+          .reveal(epoch, tree.root(), votes, proof, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd', signers[3].address);
         assertBNEqual((await voteManager.getVote(epoch, stakerIdAcc3, 0)).value, toBigNumber('100'), 'Vote not equal to 100');
         const stakeAfter = (await stakeManager.stakers(stakerIdAcc3)).stake;
         assertBNEqual(stakeBefore, stakeAfter);

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -74,13 +74,11 @@ describe('VoteManager', function () {
         await schellingCoin.transfer(signers[4].address, tokenAmount('19000'));
         await schellingCoin.transfer(signers[5].address, tokenAmount('1000'));
         await schellingCoin.transfer(signers[6].address, tokenAmount('1000'));
-        await schellingCoin.transfer(signers[7].address, tokenAmount('1000'));
 
         await schellingCoin.connect(signers[3]).approve(stakeManager.address, tokenAmount('420000'));
         await schellingCoin.connect(signers[4]).approve(stakeManager.address, tokenAmount('19000'));
         await schellingCoin.connect(signers[5]).approve(stakeManager.address, tokenAmount('1000'));
         await schellingCoin.connect(signers[6]).approve(stakeManager.address, tokenAmount('1000'));
-        await schellingCoin.connect(signers[7]).approve(stakeManager.address, tokenAmount('1000'));
 
         const epoch = await getEpoch();
         await stakeManager.connect(signers[3]).stake(epoch, tokenAmount('420000'));
@@ -335,7 +333,6 @@ describe('VoteManager', function () {
 
         const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
         const tree = merkle('keccak256').sync(votes);
-        await stakeManager.connect(signers[7]).stake(epoch, tokenAmount('1000'));
         const proof = [];
         for (let i = 0; i < votes.length; i++) {
           proof.push(tree.getProofPath(i, true, true));
@@ -380,11 +377,6 @@ describe('VoteManager', function () {
           ['uint256', 'uint256', 'bytes32'],
           [epoch, root, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd']
         );
-        const commitment2 = utils.solidityKeccak256(
-          ['uint256', 'uint256', 'bytes32'],
-          [epoch, root, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd']
-        );
-        await voteManager.connect(signers[7]).commit(epoch, commitment2);
         await voteManager.connect(signers[3]).commit(epoch, commitment1);
 
         const proof = [];

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -399,8 +399,8 @@ describe('VoteManager', function () {
         await stakeManager.setStakerStake(1, tokenAmount('1000000'), 'increase reward', epoch);
         const tx = await voteManager.connect(signers[3])
           .reveal(epoch, tree.root(), votes, proof, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd', signers[3].address);
-        
-        assert(tx,"it was not able to reveal");
+
+        assert(tx, 'it was not able to reveal');
       });
 
       it('Account 3 should not get rewards since lower cutOffs length of previous block was zero', async function () {


### PR DESCRIPTION
https://blog.soliditylang.org/2020/12/16/solidity-v0.8.0-release-announcement/. As per this link evm might revert a transaction when there is underflow or overflow. Based on the ternary condition, the rewardPool - reward will only execute, when rewardPool >= reward else it will return 0. this will prevent underflow conditions. 
fixes #178 