### PR TITLE
Redundant code : CheckState And checkEpoch in rewardManager.sol

### DIFF
--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -18,16 +18,6 @@ contract RewardManager is Initializable, ACL, Constants {
     IVoteManager public voteManager;
     IBlockManager public blockManager;
 
-    modifier checkEpoch(uint32 epoch) {
-        require(epoch == parameters.getEpoch(), "incorrect epoch");
-        _;
-    }
-
-    modifier checkState(uint256 state) {
-        require(state == parameters.getState(), "incorrect state");
-        _;
-    }
-
     /// @param stakeManagerAddress The address of the VoteManager contract
     /// @param voteManagersAddress The address of the VoteManager contract
     /// @param blockManagerAddress The address of the BlockManager contract


### PR DESCRIPTION
We can inherit modifiers from Statemanger if we need to use it in any new method.  Currently no method in RewardManager uses both modifiers.