### PR TITLE
Add Power to Job and Collections

### DIFF
--- a/contracts/Core/AssetManager.sol
+++ b/contracts/Core/AssetManager.sol
@@ -73,10 +73,10 @@ contract AssetManager is ACL, AssetStorage, Constants {
 
     function createJob(
         bool repeat,
+        int8 power,
         string calldata name,
         string calldata selector,
-        string calldata url,
-        int8 power
+        string calldata url
     ) external onlyRole(ASSET_MODIFIER_ROLE) {
         numAssets = numAssets + 1;
         uint32 epoch = parameters.getEpoch();
@@ -88,9 +88,9 @@ contract AssetManager is ACL, AssetStorage, Constants {
 
     function updateJob(
         uint8 jobID,
+        int8 power,
         string calldata selector,
-        string calldata url,
-        int8 power
+        string calldata url
     ) external onlyRole(ASSET_MODIFIER_ROLE) {
         require(jobs[jobID].assetType == uint8(assetTypes.Job), "Job ID not present");
 
@@ -123,8 +123,8 @@ contract AssetManager is ACL, AssetStorage, Constants {
     function createCollection(
         uint8[] memory jobIDs,
         uint32 aggregationMethod,
-        string calldata name,
-        int8 power
+        int8 power,
+        string calldata name
     ) external onlyRole(ASSET_MODIFIER_ROLE) {
         require(aggregationMethod > 0 && aggregationMethod < parameters.aggregationRange(), "Aggregation range out of bounds");
 
@@ -208,16 +208,16 @@ contract AssetManager is ACL, AssetStorage, Constants {
         returns (
             bool active,
             bool repeat,
+            int8 power,
             string memory name,
             string memory selector,
-            string memory url,
-            int8 power
+            string memory url
         )
     {
         require(jobs[id].assetType == uint8(assetTypes.Job), "ID is not a job");
 
         Structs.Job memory job = jobs[id];
-        return (job.active, job.repeat, job.name, job.selector, job.url, job.power);
+        return (job.active, job.repeat, job.power, job.name, job.selector, job.url);
     }
 
     function getCollection(uint8 id)
@@ -225,20 +225,20 @@ contract AssetManager is ACL, AssetStorage, Constants {
         view
         returns (
             bool active,
+            int8 power,
             uint8[] memory jobIDs,
             uint32 aggregationMethod,
-            string memory name,
-            int8 power
+            string memory name
         )
     {
         require(collections[id].assetType == uint8(assetTypes.Collection), "ID is not a collection");
 
         return (
             collections[id].active,
+            collections[id].power,
             collections[id].jobIDs,
             collections[id].aggregationMethod,
-            collections[id].name,
-            collections[id].power
+            collections[id].name
         );
     }
 

--- a/contracts/Core/AssetManager.sol
+++ b/contracts/Core/AssetManager.sol
@@ -8,7 +8,7 @@ import "./ACL.sol";
 
 contract AssetManager is ACL, AssetStorage, Constants {
     IParameters public parameters;
-    
+
     event JobCreated(
         bool repeat,
         uint8 id,
@@ -233,7 +233,13 @@ contract AssetManager is ACL, AssetStorage, Constants {
     {
         require(collections[id].assetType == uint8(assetTypes.Collection), "ID is not a collection");
 
-        return (collections[id].active, collections[id].jobIDs, collections[id].aggregationMethod, collections[id].name, collections[id].power);
+        return (
+            collections[id].active,
+            collections[id].jobIDs,
+            collections[id].aggregationMethod,
+            collections[id].name,
+            collections[id].power
+        );
     }
 
     function getAssetType(uint8 id) external view returns (uint8) {

--- a/contracts/lib/Structs.sol
+++ b/contracts/lib/Structs.sol
@@ -47,7 +47,7 @@ library Structs {
         bool repeat;
         uint8 id;
         uint8 assetType;
-        uint8 power;
+        int8 power;
         uint32 epoch;
         address creator;
         string name;
@@ -59,9 +59,9 @@ library Structs {
         bool active;
         uint8 id;
         uint8 assetType;
-        uint8 power;
-        uint32 aggregationMethod;
+        int8 power;
         uint32 epoch;
+        uint32 aggregationMethod;
         uint8[] jobIDs;
         address creator;
         mapping(uint8 => bool) jobIDExist;

--- a/contracts/lib/Structs.sol
+++ b/contracts/lib/Structs.sol
@@ -47,8 +47,9 @@ library Structs {
         bool repeat;
         uint8 id;
         uint8 assetType;
-        address creator;
+        uint8 power;
         uint32 epoch;
+        address creator;
         string name;
         string selector;
         string url;
@@ -58,10 +59,11 @@ library Structs {
         bool active;
         uint8 id;
         uint8 assetType;
-        uint8[] jobIDs;
-        address creator;
+        uint8 power;
         uint32 aggregationMethod;
         uint32 epoch;
+        uint8[] jobIDs;
+        address creator;
         mapping(uint8 => bool) jobIDExist;
         string name;
     }

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -328,7 +328,7 @@ describe('Access Control Test', async () => {
     await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
     await assetManager.createJob(true, 0, 'http://testurl.com/2', 'selector/2', 'test2');
     await assetManager.createCollection([1, 2], 1, 0, 'test');
-    await assetManager.createJob('http://testurl.com/3', 'selector/3', 'test3', true, 0);
+    await assetManager.createJob(true, 0, 'http://testurl.com/3', 'selector/3', 'test3');
     await assetManager.addJobToCollection(3, 4);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.addJobToCollection(3, 4), expectedRevertMessage);

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -203,53 +203,53 @@ describe('Access Control Test', async () => {
 
   it('createJob() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true), expectedRevertMessage);
+    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true), expectedRevertMessage);
+    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true), expectedRevertMessage);
+    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true), expectedRevertMessage);
+    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
   });
 
   it('createJob() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true);
+    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true), expectedRevertMessage);
+    await assertRevert(assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0), expectedRevertMessage);
   });
 
   it('updateJob() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
   });
 
   it('updateJob() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true);
-    await assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2');
+    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
+    await assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
   });
 
   it('setAssetStatus() should not be accessable by anyone besides AssetCreator', async () => {
@@ -272,7 +272,7 @@ describe('Access Control Test', async () => {
   it('setAssetStatus() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true);
+    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
     await assetManager.setAssetStatus(true, 1);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.setAssetStatus(true, 1), expectedRevertMessage);
@@ -280,29 +280,29 @@ describe('Access Control Test', async () => {
 
   it('createCollection() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test'), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test'), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test'), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test'), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
   });
 
   it('createCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true);
-    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true);
-    await assetManager.createCollection([1, 2], 1, 'test');
+    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
+    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0);
+    await assetManager.createCollection([1, 2], 1, 'test', 0);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test'), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
   });
 
   it('addJobToCollection() should not be accessable by anyone besides AssetCreator', async () => {
@@ -325,10 +325,10 @@ describe('Access Control Test', async () => {
   it('addJobToCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true);
-    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true);
-    await assetManager.createCollection([1, 2], 1, 'test');
-    await assetManager.createJob('http://testurl.com/3', 'selector/3', 'test3', true);
+    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
+    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0);
+    await assetManager.createCollection([1, 2], 1, 'test', 0);
+    await assetManager.createJob('http://testurl.com/3', 'selector/3', 'test3', true, 0);
     await assetManager.addJobToCollection(3, 4);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.addJobToCollection(3, 4), expectedRevertMessage);
@@ -354,9 +354,9 @@ describe('Access Control Test', async () => {
   it('removeJobFromCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true);
-    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true);
-    await assetManager.createCollection([1, 2], 1, 'test');
+    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
+    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0);
+    await assetManager.createCollection([1, 2], 1, 'test', 0);
     await assetManager.removeJobFromCollection(3, 1);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.removeJobFromCollection(3, 1), expectedRevertMessage);

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -203,53 +203,53 @@ describe('Access Control Test', async () => {
 
   it('createJob() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
   });
 
   it('createJob() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
+    await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(true, 0, 'http://testurl.com/2', 'selector/2', 'test2'), expectedRevertMessage);
   });
 
   it('updateJob() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 2, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 2, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 2, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 2, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
   });
 
   it('updateJob() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
-    await assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2);
+    await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.updateJob(1, 2, 'http://testurl.com/2', 'selector/2');
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 'http://testurl.com/2', 'selector/2', 2), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 2, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
   });
 
   it('setAssetStatus() should not be accessable by anyone besides AssetCreator', async () => {
@@ -272,7 +272,7 @@ describe('Access Control Test', async () => {
   it('setAssetStatus() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
+    await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
     await assetManager.setAssetStatus(true, 1);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.setAssetStatus(true, 1), expectedRevertMessage);
@@ -280,29 +280,29 @@ describe('Access Control Test', async () => {
 
   it('createCollection() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 0, 'test'), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 0, 'test'), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 0, 'test'), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 0, 'test'), expectedRevertMessage);
   });
 
   it('createCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
-    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0);
-    await assetManager.createCollection([1, 2], 1, 'test', 0);
+    await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(true, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createCollection([1, 2], 1, 0, 'test');
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.createCollection([1, 2], 1, 'test', 0), expectedRevertMessage);
+    await assertRevert(assetManager.createCollection([1, 2], 1, 0, 'test'), expectedRevertMessage);
   });
 
   it('addJobToCollection() should not be accessable by anyone besides AssetCreator', async () => {
@@ -325,9 +325,9 @@ describe('Access Control Test', async () => {
   it('addJobToCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
-    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0);
-    await assetManager.createCollection([1, 2], 1, 'test', 0);
+    await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(true, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createCollection([1, 2], 1, 0, 'test');
     await assetManager.createJob('http://testurl.com/3', 'selector/3', 'test3', true, 0);
     await assetManager.addJobToCollection(3, 4);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
@@ -354,9 +354,9 @@ describe('Access Control Test', async () => {
   it('removeJobFromCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob('http://testurl.com/1', 'selector/1', 'test1', true, 0);
-    await assetManager.createJob('http://testurl.com/2', 'selector/2', 'test2', true, 0);
-    await assetManager.createCollection([1, 2], 1, 'test', 0);
+    await assetManager.createJob(true, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(true, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createCollection([1, 2], 1, 0, 'test');
     await assetManager.removeJobFromCollection(3, 1);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.removeJobFromCollection(3, 1), expectedRevertMessage);

--- a/test/AssetManager.js
+++ b/test/AssetManager.js
@@ -56,7 +56,7 @@ describe('AssetManager', function () {
         power,
         name,
         selector,
-        url,
+        url
       );
 
       const collectionName = 'Test Collection';

--- a/test/AssetManager.js
+++ b/test/AssetManager.js
@@ -36,7 +36,7 @@ describe('AssetManager', function () {
       const name = 'test';
       const repeat = true;
       const power = -2;
-      await assetManager.createJob(repeat, name, selector, url, power);
+      await assetManager.createJob(repeat, power, name, selector, url);
       const job = await assetManager.jobs(1);
       assert(job.url === url);
       assert(job.selector === selector);
@@ -53,14 +53,14 @@ describe('AssetManager', function () {
       const power = 3;
       await assetManager.createJob(
         repeat,
+        power,
         name,
         selector,
         url,
-        power
       );
 
       const collectionName = 'Test Collection';
-      await assetManager.createCollection([1, 2], 1, collectionName, power);
+      await assetManager.createCollection([1, 2], 1, power, collectionName);
       const collection = await assetManager.getCollection(3);
       assert(collection.name === collectionName);
       assertBNEqual(collection.aggregationMethod, toBigNumber('1'));
@@ -74,7 +74,7 @@ describe('AssetManager', function () {
       const name = 'test3';
       const repeat = true;
       const power = -6;
-      await assetManager.createJob(repeat, name, selector, url, power);
+      await assetManager.createJob(repeat, power, name, selector, url);
 
       await assetManager.addJobToCollection(3, 4);
       const collection = await assetManager.getCollection(3);
@@ -95,8 +95,8 @@ describe('AssetManager', function () {
     });
 
     it('should be able to update Job', async function () {
-      await assetManager.createJob(true, 'test4', 'selector/4', 'http://testurl.com/4', 6);
-      await assetManager.updateJob(5, 'selector/5', 'http://testurl.com/5', 4);
+      await assetManager.createJob(true, 6, 'test4', 'selector/4', 'http://testurl.com/4');
+      await assetManager.updateJob(5, 4, 'selector/5', 'http://testurl.com/5');
       const job = await assetManager.jobs(5);
       assert(job.url === 'http://testurl.com/5');
       assert(job.selector === 'selector/5');
@@ -119,7 +119,7 @@ describe('AssetManager', function () {
     });
 
     it('should not be able to create collection with inactive jobs', async function () {
-      const tx = assetManager.createCollection([1, 5], 2, 'Test Collection', 0);
+      const tx = assetManager.createCollection([1, 5], 2, 0, 'Test Collection');
       await assertRevert(tx, 'Job ID not active');
     });
 
@@ -155,7 +155,7 @@ describe('AssetManager', function () {
 
     it('should be able to inactivate collection', async function () {
       const collectionName = 'Test Collection6';
-      await assetManager.createCollection([1, 2], 2, collectionName, 0);
+      await assetManager.createCollection([1, 2], 2, 0, collectionName);
       await assetManager.setAssetStatus(false, 6);
       const collectionIsActive = await assetManager.getActiveStatus(6);
       assert(collectionIsActive === false);
@@ -179,7 +179,7 @@ describe('AssetManager', function () {
     });
 
     it('should not be able to update job if job does not exist', async function () {
-      const tx = assetManager.updateJob(9, 'http://testurl.com/4', 'selector/4', 2);
+      const tx = assetManager.updateJob(9, 2, 'http://testurl.com/4', 'selector/4');
       await assertRevert(tx, 'Job ID not present');
     });
 
@@ -216,29 +216,29 @@ describe('AssetManager', function () {
 
     it('should not create a collection if one of the jobIDs is not a job', async function () {
       const collectionName = 'Test Collection2';
-      const tx = assetManager.createCollection([1, 2, 3], 2, collectionName, 0);
+      const tx = assetManager.createCollection([1, 2, 3], 2, 0, collectionName);
       await assertRevert(tx, 'Job ID not present');
     });
 
     it('should not create collection if it does not have more than 1 or any jobIDs', async function () {
       const collectionName = 'Test Collection2';
-      const tx1 = assetManager.createCollection([], 1, collectionName, 0);
+      const tx1 = assetManager.createCollection([], 1, 0, collectionName);
       await assertRevert(tx1, 'Number of jobIDs low to create collection');
-      const tx2 = assetManager.createCollection([1], 1, collectionName, 0);
+      const tx2 = assetManager.createCollection([1], 1, 0, collectionName);
       await assertRevert(tx2, 'Number of jobIDs low to create collection');
     });
 
     it('aggregationMethod should not be equal to 0 or greater than 3', async function () {
       const collectionName = 'Test Collection2';
-      const tx1 = assetManager.createCollection([1, 2, 5], 4, collectionName, 0);
+      const tx1 = assetManager.createCollection([1, 2, 5], 4, 0, collectionName);
       await assertRevert(tx1, 'Aggregation range out of bounds');
-      const tx2 = assetManager.createCollection([1, 2, 5], 0, collectionName, 0);
+      const tx2 = assetManager.createCollection([1, 2, 5], 0, 0, collectionName);
       await assertRevert(tx2, 'Aggregation range out of bounds');
     });
 
     it('should not create collection if duplicates jobIDs are present', async function () {
       const collectionName = 'Test Collection2';
-      const tx = assetManager.createCollection([1, 2, 2, 5], 1, collectionName, 0);
+      const tx = assetManager.createCollection([1, 2, 2, 5], 1, 0, collectionName);
       await assertRevert(tx, 'Duplicate JobIDs sent');
     });
 

--- a/test/AssetManager.js
+++ b/test/AssetManager.js
@@ -35,7 +35,8 @@ describe('AssetManager', function () {
       const selector = 'selector';
       const name = 'test';
       const repeat = true;
-      await assetManager.createJob(repeat, name, selector, url);
+      const power = -2;
+      await assetManager.createJob(repeat, name, selector, url, power);
       const job = await assetManager.jobs(1);
       assert(job.url === url);
       assert(job.selector === selector);
@@ -49,15 +50,17 @@ describe('AssetManager', function () {
       const selector = 'selector/2';
       const name = 'test2';
       const repeat = true;
+      const power = 3;
       await assetManager.createJob(
         repeat,
         name,
         selector,
-        url
+        url,
+        power
       );
 
       const collectionName = 'Test Collection';
-      await assetManager.createCollection([1, 2], 1, collectionName);
+      await assetManager.createCollection([1, 2], 1, collectionName, power);
       const collection = await assetManager.getCollection(3);
       assert(collection.name === collectionName);
       assertBNEqual(collection.aggregationMethod, toBigNumber('1'));
@@ -70,7 +73,8 @@ describe('AssetManager', function () {
       const selector = 'selector/3';
       const name = 'test3';
       const repeat = true;
-      await assetManager.createJob(repeat, name, selector, url);
+      const power = -6;
+      await assetManager.createJob(repeat, name, selector, url, power);
 
       await assetManager.addJobToCollection(3, 4);
       const collection = await assetManager.getCollection(3);
@@ -91,11 +95,12 @@ describe('AssetManager', function () {
     });
 
     it('should be able to update Job', async function () {
-      await assetManager.createJob(true, 'test4', 'selector/4', 'http://testurl.com/4');
-      await assetManager.updateJob(5, 'selector/5', 'http://testurl.com/5');
+      await assetManager.createJob(true, 'test4', 'selector/4', 'http://testurl.com/4', 6);
+      await assetManager.updateJob(5, 'selector/5', 'http://testurl.com/5', 4);
       const job = await assetManager.jobs(5);
       assert(job.url === 'http://testurl.com/5');
       assert(job.selector === 'selector/5');
+      assertBNEqual(job.power, toBigNumber('4'));
     });
 
     it('should be able to inactivate Job', async function () {
@@ -114,7 +119,7 @@ describe('AssetManager', function () {
     });
 
     it('should not be able to create collection with inactive jobs', async function () {
-      const tx = assetManager.createCollection([1, 5], 2, 'Test Collection');
+      const tx = assetManager.createCollection([1, 5], 2, 'Test Collection', 0);
       await assertRevert(tx, 'Job ID not active');
     });
 
@@ -150,7 +155,7 @@ describe('AssetManager', function () {
 
     it('should be able to inactivate collection', async function () {
       const collectionName = 'Test Collection6';
-      await assetManager.createCollection([1, 2], 2, collectionName);
+      await assetManager.createCollection([1, 2], 2, collectionName, 0);
       await assetManager.setAssetStatus(false, 6);
       const collectionIsActive = await assetManager.getActiveStatus(6);
       assert(collectionIsActive === false);
@@ -174,7 +179,7 @@ describe('AssetManager', function () {
     });
 
     it('should not be able to update job if job does not exist', async function () {
-      const tx = assetManager.updateJob(9, 'http://testurl.com/4', 'selector/4');
+      const tx = assetManager.updateJob(9, 'http://testurl.com/4', 'selector/4', 2);
       await assertRevert(tx, 'Job ID not present');
     });
 
@@ -211,29 +216,29 @@ describe('AssetManager', function () {
 
     it('should not create a collection if one of the jobIDs is not a job', async function () {
       const collectionName = 'Test Collection2';
-      const tx = assetManager.createCollection([1, 2, 3], 2, collectionName);
+      const tx = assetManager.createCollection([1, 2, 3], 2, collectionName, 0);
       await assertRevert(tx, 'Job ID not present');
     });
 
     it('should not create collection if it does not have more than 1 or any jobIDs', async function () {
       const collectionName = 'Test Collection2';
-      const tx1 = assetManager.createCollection([], 1, collectionName);
+      const tx1 = assetManager.createCollection([], 1, collectionName, 0);
       await assertRevert(tx1, 'Number of jobIDs low to create collection');
-      const tx2 = assetManager.createCollection([1], 1, collectionName);
+      const tx2 = assetManager.createCollection([1], 1, collectionName, 0);
       await assertRevert(tx2, 'Number of jobIDs low to create collection');
     });
 
     it('aggregationMethod should not be equal to 0 or greater than 3', async function () {
       const collectionName = 'Test Collection2';
-      const tx1 = assetManager.createCollection([1, 2, 5], 4, collectionName);
+      const tx1 = assetManager.createCollection([1, 2, 5], 4, collectionName, 0);
       await assertRevert(tx1, 'Aggregation range out of bounds');
-      const tx2 = assetManager.createCollection([1, 2, 5], 0, collectionName);
+      const tx2 = assetManager.createCollection([1, 2, 5], 0, collectionName, 0);
       await assertRevert(tx2, 'Aggregation range out of bounds');
     });
 
     it('should not create collection if duplicates jobIDs are present', async function () {
       const collectionName = 'Test Collection2';
-      const tx = assetManager.createCollection([1, 2, 2, 5], 1, collectionName);
+      const tx = assetManager.createCollection([1, 2, 2, 5], 1, collectionName, 0);
       await assertRevert(tx, 'Duplicate JobIDs sent');
     });
 
@@ -248,7 +253,7 @@ describe('AssetManager', function () {
     });
 
     it('should not add jobID to a collection if the jobID specified is not a Job', async function () {
-    // jobID does not exist
+      // jobID does not exist
       const tx = assetManager.addJobToCollection(3, 7);
       await assertRevert(tx, 'Job ID not present');
       // jobID specified is a collection


### PR DESCRIPTION
Fixes #266 
With this addition 
We have added the required flexibility for reporting results. 

A new parameter called as power is added to job and collection.

In a job, power signifies how the staker should interpret and convert the value fetched from API 
in collection, power signifies how a staker should vote and how client should interpret the result 

for example lets take a collection A<>B
it has 2 jobs 
job 1 : value : 100 power : 2
job 2 : value : 100000 power : -1

staker when aggregate, aggregate it by expanding
100,00, 100,00

and propose w.r.t power of collection, let's say it is 2 
then a result of collection would be 

result: 100
power: 2