### PR TITLE
Made assetId consistent | 1 to N throughout

### DIFF
--- a/contracts/Core/BlockManager.sol
+++ b/contracts/Core/BlockManager.sol
@@ -91,7 +91,7 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager {
             Structs.Vote memory vote = voteManager.getVote(lastVisitedStaker);
             require(vote.epoch == epoch, "epoch in vote doesnt match with current");
 
-            uint48 value = vote.values[assetId-1];
+            uint48 value = vote.values[assetId - 1];
             uint256 influence = voteManager.getInfluenceSnapshot(epoch, lastVisitedStaker);
             accProd = accProd + value * influence;
             accWeight = accWeight + influence;

--- a/contracts/Core/BlockManager.sol
+++ b/contracts/Core/BlockManager.sol
@@ -91,7 +91,7 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager {
             Structs.Vote memory vote = voteManager.getVote(lastVisitedStaker);
             require(vote.epoch == epoch, "epoch in vote doesnt match with current");
 
-            uint48 value = vote.values[assetId];
+            uint48 value = vote.values[assetId-1];
             uint256 influence = voteManager.getInfluenceSnapshot(epoch, lastVisitedStaker);
             accProd = accProd + value * influence;
             accWeight = accWeight + influence;

--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -126,7 +126,7 @@ contract RewardManager is Initializable, ACL, Constants {
         if (mediansLastEpoch.length == 0) return;
         uint64 penalty = 0;
         for (uint8 i = 0; i < mediansLastEpoch.length; i++) {
-            uint32 voteValueLastEpoch = voteManager.getVoteValue(i, stakerId);
+            uint32 voteValueLastEpoch = voteManager.getVoteValue(i + 1, stakerId);
             // uint32 voteWeightLastEpoch = voteManager.getVoteWeight(thisStaker.id, i);
             uint32 medianLastEpoch = mediansLastEpoch[i];
             if (medianLastEpoch == 0) continue;

--- a/contracts/Core/VoteManager.sol
+++ b/contracts/Core/VoteManager.sol
@@ -115,17 +115,17 @@ contract VoteManager is Initializable, ACL, VoteStorage, StateManager {
     }
 
     function getVote(uint32 stakerId) external view returns (Structs.Vote memory vote) {
-        //stakerid -> assetid -> vote
+        //stakerid->votes
         return (votes[stakerId]);
     }
 
     function getVoteValue(uint8 assetId, uint32 stakerId) external view returns (uint48) {
         //stakerid -> assetid -> vote
-        return (votes[stakerId].values[assetId]);
+        return (votes[stakerId].values[assetId-1]);
     }
 
     function getInfluenceSnapshot(uint32 epoch, uint32 stakerId) external view returns (uint256) {
-        //epoch -> assetid -> voteValue -> weight
+        //epoch -> stakerId
         return (influenceSnapshot[epoch][stakerId]);
     }
 

--- a/contracts/Core/VoteManager.sol
+++ b/contracts/Core/VoteManager.sol
@@ -121,7 +121,7 @@ contract VoteManager is Initializable, ACL, VoteStorage, StateManager {
 
     function getVoteValue(uint8 assetId, uint32 stakerId) external view returns (uint48) {
         //stakerid -> assetid -> vote
-        return (votes[stakerId].values[assetId-1]);
+        return (votes[stakerId].values[assetId - 1]);
     }
 
     function getInfluenceSnapshot(uint32 epoch, uint32 stakerId) external view returns (uint256) {

--- a/test/BlockManager.js
+++ b/test/BlockManager.js
@@ -206,10 +206,10 @@ describe('BlockManager', function () {
         stakeManager,
         epoch);
 
-      await blockManager.connect(signers[19]).giveSorted(epoch, 1, sortedStakers);
+      await blockManager.connect(signers[19]).giveSorted(epoch, 2, sortedStakers);
 
       const dispute = await blockManager.disputes(epoch, signers[19].address);
-      assertBNEqual(dispute.assetId, toBigNumber('1'), 'assetId should match');
+      assertBNEqual(dispute.assetId, toBigNumber('2'), 'assetId should match');
       assertBNEqual(dispute.accWeight, totalInfluenceRevealed, 'totalInfluenceRevealed should match');
       assertBNEqual(dispute.lastVisitedStaker, sortedStakers[sortedStakers.length - 1], 'lastVisited should match');
     });
@@ -324,9 +324,9 @@ describe('BlockManager', function () {
         stakeManager,
         epoch);
 
-      await blockManager.connect(signers[19]).giveSorted(epoch, 1, res1.sortedStakers);
+      await blockManager.connect(signers[19]).giveSorted(epoch, 2, res1.sortedStakers);
       const firstDispute = await blockManager.disputes(epoch, signers[19].address);
-      assertBNEqual(firstDispute.assetId, toBigNumber('1'), 'assetId should match');
+      assertBNEqual(firstDispute.assetId, toBigNumber('2'), 'assetId should match');
       assertBNEqual(firstDispute.accWeight, res1.totalInfluenceRevealed, 'totalInfluenceRevealed should match');
       assertBNEqual(firstDispute.lastVisitedStaker, res1.sortedStakers[res1.sortedStakers.length - 1], 'lastVisited should match');
 
@@ -348,11 +348,11 @@ describe('BlockManager', function () {
         stakeManager,
         epoch);
 
-      await blockManager.connect(signers[15]).giveSorted(epoch, 2, res2.sortedStakers);
+      await blockManager.connect(signers[15]).giveSorted(epoch, 3, res2.sortedStakers);
 
       const secondDispute = await blockManager.disputes(epoch, signers[15].address);
 
-      assertBNEqual(secondDispute.assetId, toBigNumber('2'), 'assetId should match');
+      assertBNEqual(secondDispute.assetId, toBigNumber('3'), 'assetId should match');
       assertBNEqual(secondDispute.accWeight, res2.totalInfluenceRevealed, 'totalInfluenceRevealed should match');
       assertBNEqual(secondDispute.lastVisitedStaker, res2.sortedStakers[res2.sortedStakers.length - 1], 'lastVisited should match');
 
@@ -429,10 +429,10 @@ describe('BlockManager', function () {
 
       const sortedStakers = [5];
 
-      await blockManager.connect(signers[15]).giveSorted(epoch, 1, sortedStakers);
+      await blockManager.connect(signers[15]).giveSorted(epoch, 2, sortedStakers);
 
       const beforeDisputeReset = await blockManager.disputes(epoch, signers[15].address);
-      assertBNEqual(beforeDisputeReset.assetId, toBigNumber('1'), 'assetId should match');
+      assertBNEqual(beforeDisputeReset.assetId, toBigNumber('2'), 'assetId should match');
 
       await blockManager.connect(signers[15]).resetDispute(epoch);
       const afterDisputeReset = await blockManager.disputes(epoch, signers[15].address);
@@ -507,11 +507,11 @@ describe('BlockManager', function () {
         epoch);
 
       // Dispute in batches
-      await blockManager.connect(signers[19]).giveSorted(epoch, 1, [6]);
-      await blockManager.connect(signers[19]).giveSorted(epoch, 1, [7]);
+      await blockManager.connect(signers[19]).giveSorted(epoch, 2, [6]);
+      await blockManager.connect(signers[19]).giveSorted(epoch, 2, [7]);
       const dispute = await blockManager.disputes(epoch, signers[19].address);
 
-      assertBNEqual(dispute.assetId, toBigNumber('1'), 'assetId should match');
+      assertBNEqual(dispute.assetId, toBigNumber('2'), 'assetId should match');
       assertBNEqual(dispute.accWeight, totalInfluenceRevealed, 'totalInfluenceRevealed should match');
       assertBNEqual(dispute.accProd, accProd, 'accProd should match');
       assertBNEqual(dispute.lastVisitedStaker, sortedStakers[sortedStakers.length - 1], 'lastVisited should match');
@@ -551,7 +551,7 @@ describe('BlockManager', function () {
       const tx = blockManager.connect(signers[19]).giveSorted(epoch, 1, [8]);
       assertRevert(tx, 'epoch in vote doesnt match with current');
     });
-    it('should not be able to give sorted votes for wrong asset ID', async function () {
+    it('For the second batch while raising dispute, assetid should match to the disputed assetid of first batch', async function () {
       await mineToNextEpoch();
       const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
       const epoch = await getEpoch();

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -173,7 +173,7 @@ describe('VoteManager', function () {
         // // Correct Reveal
         await voteManager.connect(signers[3]).reveal(epoch, votes,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd'); // arguments getvVote => epoch, stakerId, assetId
-        assertBNEqual((await voteManager.getVoteValue(0, stakerIdAcc3)), toBigNumber('100'), 'Vote not equal to 100');
+        assertBNEqual((await voteManager.getVoteValue(1, stakerIdAcc3)), toBigNumber('100'), 'Vote not equal to 100');
 
         const votes2 = [104, 204, 304, 404, 504, 604, 704, 804, 904];
         //
@@ -255,7 +255,7 @@ describe('VoteManager', function () {
 
         await voteManager.connect(signers[3]).reveal(epoch, votes,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd'); // arguments getvVote => epoch, stakerId, assetId
-        assertBNEqual((await voteManager.getVoteValue(0, stakerIdAcc3)), toBigNumber('100'), 'Vote not equal to 100');
+        assertBNEqual((await voteManager.getVoteValue(1, stakerIdAcc3)), toBigNumber('100'), 'Vote not equal to 100');
 
         await voteManager.connect(signers[4]).reveal(epoch, votes2,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd');
@@ -393,7 +393,7 @@ describe('VoteManager', function () {
 
         await voteManager.connect(signers[3]).reveal(epoch, votes,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd'); // arguments getvVote => epoch, stakerId, assetId
-        assertBNEqual((await voteManager.getVoteValue(0, stakerIdAcc3)), toBigNumber('100'), 'Vote not equal to 100');
+        assertBNEqual((await voteManager.getVoteValue(1, stakerIdAcc3)), toBigNumber('100'), 'Vote not equal to 100');
 
         // const ageAfter = (await stakeManager.stakers(stakerIdAcc3)).age;
         // assertBNEqual(ageBefore.add(10000), ageAfter);


### PR DESCRIPTION
Fixes #182 

VoteManager stores votes from 0..n-1 for assets with assetids 1 to n

It mainly impacted two functions
getVoteValue 
and 
giveSortedVotes

In both places, the user earlier had to pass assetid-1 as assetid to get the required results.
both have been solved by this PR.
now user don't have to pass -1, he passes from 1 to N only, we do -1 inside
please check tests to see how its changed