### PR TITLE
Removed checkEpoch Modifier from stateManager.sol

### DIFF
--- a/contracts/Core/StateManager.sol
+++ b/contracts/Core/StateManager.sol
@@ -4,11 +4,6 @@ pragma solidity ^0.8.0;
 import "./storage/Constants.sol";
 
 contract StateManager is Constants {
-    modifier checkEpoch(uint32 epoch, uint32 epochLength) {
-        require(epoch == getEpoch(epochLength), "incorrect epoch");
-        _;
-    }
-
     modifier checkState(State state, uint32 epochLength) {
         require(state == getState(epochLength), "incorrect state");
         _;


### PR DESCRIPTION
Fixes #348 
Removed checkEpoch Modifier from  "stateManager.sol"  file as it was not being used anywhere.