### PR TITLE
Test for modifier Initializer 

### DIFF
--- a/contracts/Core/StateManager.sol
+++ b/contracts/Core/StateManager.sol
@@ -4,11 +4,6 @@ pragma solidity ^0.8.0;
 import "./storage/Constants.sol";
 
 contract StateManager is Constants {
-    modifier checkEpoch(uint32 epoch, uint32 epochLength) {
-        require(epoch == getEpoch(epochLength), "incorrect epoch");
-        _;
-    }
-
     modifier checkState(State state, uint32 epochLength) {
         require(state == getState(epochLength), "incorrect state");
         _;

--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../Initializable.sol";
+
+/**
+ * @title InitializableMock
+ * @dev This contract is a mock to test initializable functionality
+ */
+contract InitializableMock is Initializable {
+    bool public initializerRan;
+
+    function initialize() public initializer {
+        initializerRan = true;
+    }
+
+    function initializeNested() public initializer {
+        initialize();
+    }
+}

--- a/test/Initializable.js
+++ b/test/Initializable.js
@@ -1,0 +1,31 @@
+const { assert } = require('chai');
+const {
+  assertRevert,
+} = require('./helpers/testHelpers');
+
+const InitializableMock = artifacts.require('../contracts/mocks/InitializableMock');
+
+describe('Initializable', function () {
+  beforeEach('deploying', async function () {
+    this.contract = await InitializableMock.new();
+  });
+
+  it('initializer has not run', async function () {
+    assert.isFalse(await this.contract.initializerRan());
+  });
+
+  it('initializer has run', async function () {
+    await this.contract.initialize();
+    assert.isTrue(await this.contract.initializerRan());
+  });
+
+  it('initializer does not run again', async function () {
+    await this.contract.initialize();
+    await assertRevert(this.contract.initialize(), 'Initializable: contract is already initialized');
+  });
+
+  it('initializer has run after nested initialization', async function () {
+    await this.contract.initializeNested();
+    assert.isTrue(await this.contract.initializerRan());
+  });
+});


### PR DESCRIPTION
#350
Here added thet test case for checking modifier Initializer.

Taken reference from OpenZeppelin. They have written a mock file which has function that uses modifier 'Initializer' & one more function initializeNested which also uses modifier 'initializer'.

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/utils/Initializable.sol

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/b9125001f0a1c44d596ca3a47536f1a467e3a29d/contracts/mocks/InitializableMock.sol

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/b9125001f0a1c44d596ca3a47536f1a467e3a29d/test/utils/Initializable.test.js


