### PR TITLE
Inactivity bug

### DIFF
--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -80,7 +80,9 @@ contract RewardManager is Initializable, ACL, Constants {
     function _giveInactivityPenalties(uint32 epoch, uint32 stakerId) internal {
         uint32 epochLastRevealed = voteManager.getEpochLastRevealed(stakerId);
         Structs.Staker memory thisStaker = stakeManager.getStaker(stakerId);
-        uint32 epochLastActive = thisStaker.epochLastUnstakedOrFirstStaked < epochLastRevealed ? epochLastRevealed : thisStaker.epochLastUnstakedOrFirstStaked;
+        uint32 epochLastActive = thisStaker.epochLastUnstakedOrFirstStaked < epochLastRevealed
+            ? epochLastRevealed
+            : thisStaker.epochLastUnstakedOrFirstStaked;
 
         // penalize or reward if last active more than epoch - 1
         uint32 inactiveEpochs = (epoch - epochLastActive == 0) ? 0 : epoch - epochLastActive - 1;

--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -53,6 +53,10 @@ contract RewardManager is Initializable, ACL, Constants {
         stakeManager.setStakerStake(epoch, stakerId, newStake);
     }
 
+    function giveInactivityPenalties(uint32 epoch, uint32 stakerId) external onlyRole(REWARD_MODIFIER_ROLE) {
+        _giveInactivityPenalties(epoch, stakerId);
+    }
+
     /// @notice Calculates the stake and age inactivity penalties of the staker
     /// @param epochs The difference of epochs where the staker was inactive
     /// @param stakeValue The Stake that staker had in last epoch
@@ -76,7 +80,7 @@ contract RewardManager is Initializable, ACL, Constants {
     function _giveInactivityPenalties(uint32 epoch, uint32 stakerId) internal {
         uint32 epochLastRevealed = voteManager.getEpochLastRevealed(stakerId);
         Structs.Staker memory thisStaker = stakeManager.getStaker(stakerId);
-        uint32 epochLastActive = thisStaker.epochFirstStaked < epochLastRevealed ? epochLastRevealed : thisStaker.epochFirstStaked;
+        uint32 epochLastActive = thisStaker.epochLastUnstakedOrFirstStaked < epochLastRevealed ? epochLastRevealed : thisStaker.epochLastUnstakedOrFirstStaked;
 
         // penalize or reward if last active more than epoch - 1
         uint32 inactiveEpochs = (epoch - epochLastActive == 0) ? 0 : epoch - epochLastActive - 1;

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -179,8 +179,6 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause {
         require(lock.withdrawAfter != 0, "Did not unstake");
         require(lock.withdrawAfter <= epoch, "Withdraw epoch not reached");
         require(lock.withdrawAfter + parameters.withdrawReleasePeriod() >= epoch, "Release Period Passed"); // Can Use ResetLock
-        //require(staker.stake > 0, "Nonpositive Stake");
-        //require((voteManager.getCommitmentEpoch(stakerId)) != epoch, "Already commited");
 
         uint256 lockedAmount = lock.amount;
 

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -138,11 +138,21 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause {
         require(staker.stake > 0, "Nonpositive stake");
         require(locks[msg.sender][staker.tokenAddress].amount == 0, "Existing Lock");
         require(sAmount > 0, "Non-Positive Amount");
+
+        rewardManager.giveInactivityPenalties(epoch, stakerId);
+
         IStakedToken sToken = IStakedToken(staker.tokenAddress);
         require(sToken.balanceOf(msg.sender) >= sAmount, "Invalid Amount");
-        locks[msg.sender][staker.tokenAddress] = Structs.Lock(sAmount, epoch + (parameters.withdrawLockPeriod()));
 
-        emit Unstaked(epoch, stakerId, sAmount, staker.stake, block.timestamp);
+        uint256 rAmount = _convertSRZRToRZR(sAmount, staker.stake, sToken.totalSupply());
+        require(sToken.burn(msg.sender, sAmount), "Token burn Failed");
+        staker.stake = staker.stake - rAmount;
+
+        locks[msg.sender][staker.tokenAddress] = Structs.Lock(rAmount, epoch + (parameters.withdrawLockPeriod()));
+
+        staker.epochLastUnstakedOrFirstStaked = epoch;
+
+        emit Unstaked(epoch, stakerId, rAmount, staker.stake, block.timestamp);
         //emit event here
     }
 
@@ -170,22 +180,10 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause {
         require(lock.withdrawAfter != 0, "Did not unstake");
         require(lock.withdrawAfter <= epoch, "Withdraw epoch not reached");
         require(lock.withdrawAfter + parameters.withdrawReleasePeriod() >= epoch, "Release Period Passed"); // Can Use ResetLock
-        require(staker.stake > 0, "Nonpositive Stake");
-        require((voteManager.getCommitmentEpoch(stakerId)) != epoch, "Already commited");
-        if (stakerIds[msg.sender] == stakerId) {
-            // Staker Must not particiapte in withdraw lock period, To counter Hit and Run Attacks
-            require(
-                (lock.withdrawAfter - parameters.withdrawLockPeriod()) >= voteManager.getEpochLastCommitted(stakerId),
-                "Participated in Lock Period"
-            );
-        }
+        //require(staker.stake > 0, "Nonpositive Stake");
+        //require((voteManager.getCommitmentEpoch(stakerId)) != epoch, "Already commited");
 
-        IStakedToken sToken = IStakedToken(staker.tokenAddress);
-        require(sToken.balanceOf(msg.sender) >= lock.amount, "locked amount lost"); // Can Use ResetLock
-
-        uint256 rAmount = _convertSRZRToRZR(lock.amount, staker.stake, sToken.totalSupply());
-        require(sToken.burn(msg.sender, lock.amount), "Token burn Failed");
-        staker.stake = staker.stake - rAmount;
+        uint256 lockedAmount = lock.amount;
 
         // Function to Reset the lock
         _resetLock(stakerId);
@@ -193,15 +191,15 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause {
         // Transfer commission in case of delegators
         // Check commission rate >0
         if (stakerIds[msg.sender] != stakerId && staker.commission > 0) {
-            uint256 commission = (rAmount * staker.commission) / 100;
+            uint256 commission = (lockedAmount * staker.commission) / 100;
             require(razor.transfer(staker._address, commission), "couldnt transfer");
-            rAmount = rAmount - commission;
+            lockedAmount = lockedAmount - commission;
         }
 
         //Transfer stake
-        require(razor.transfer(msg.sender, rAmount), "couldnt transfer");
+        require(razor.transfer(msg.sender, lockedAmount), "couldnt transfer");
 
-        emit Withdrew(epoch, stakerId, rAmount, staker.stake, block.timestamp);
+        emit Withdrew(epoch, stakerId, lockedAmount, staker.stake, block.timestamp);
     }
 
     /// @notice remove all funds in case of emergency
@@ -247,18 +245,17 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause {
         require(stakers[stakerId].id != 0, "staker.id = 0");
 
         Structs.Staker storage staker = stakers[stakerId];
-        IStakedToken sToken = IStakedToken(stakers[stakerId].tokenAddress);
+        uint256 lockedAmount = locks[msg.sender][stakers[stakerId].tokenAddress].amount;
+        IStakedToken sToken = IStakedToken(staker.tokenAddress);
 
-        uint256 penalty = (staker.stake * parameters.resetLockPenalty()) / 100;
+        uint256 penalty = (lockedAmount * parameters.resetLockPenalty()) / 100;
+        lockedAmount = lockedAmount - penalty;
 
-        // Converting Penalty into sAmount
-        uint256 sAmount = _convertRZRtoSRZR(penalty, staker.stake, sToken.totalSupply());
-
-        //Burning sAmount from msg.sender
-        require(sToken.burn(msg.sender, sAmount), "Token burn Failed");
+        uint256 sAmount = _convertRZRtoSRZR(lockedAmount, staker.stake, sToken.totalSupply());
+        sToken.mint(msg.sender, sAmount);
 
         //Updating Staker Stake
-        staker.stake = staker.stake - penalty;
+        staker.stake = staker.stake + lockedAmount;
 
         _resetLock(stakerId);
     }
@@ -343,8 +340,8 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause {
         return stakers[stakerId].stake;
     }
 
-    function getEpochStaked(uint32 stakerId) external view returns (uint32) {
-        return stakers[stakerId].epochFirstStaked;
+    function getEpochLastUnstakedOrFirstStaked(uint32 stakerId) external view returns (uint32) {
+        return stakers[stakerId].epochLastUnstakedOrFirstStaked;
     }
 
     /// @notice Internal function for setting stake of the staker

--- a/contracts/Core/interface/IRewardManager.sol
+++ b/contracts/Core/interface/IRewardManager.sol
@@ -7,4 +7,6 @@ interface IRewardManager {
     function givePenalties(uint32 epoch, uint32 stakerId) external;
 
     function giveBlockReward(uint32 epoch, uint32 stakerId) external;
+
+    function giveInactivityPenalties(uint32 epoch, uint32 stakerId) external;
 }

--- a/contracts/lib/Structs.sol
+++ b/contracts/lib/Structs.sol
@@ -18,7 +18,7 @@ library Structs {
         address tokenAddress;
         uint32 id;
         uint32 age;
-        uint32 epochFirstStaked;
+        uint32 epochLastUnstakedOrFirstStaked;
         uint256 stake;
     }
 


### PR DESCRIPTION
Fixes #284 
Fixes #359 
> problem
> 
>     * can bypass inactivity penalty
>       -unstake() and withdraw() after inactivity since we are not checking inactivity there
> 
>     * after partial unstaking staker still cant participate
>       
>       * after returning after lock period he will get inactivity penalty
> 
> 
> solution 1
> 
>     * unstake() convert unstaked srzr to rzr and reduce from stake; add to lock 10000
> 
>     * withdraw() allow locked rzr to withdraw

> thisStaker.epochFirstStaked -> rename to thisStaker.epochLastUnstakedOrFirstStaked

