### PR TITLE
Changed modifier name and added it in update collection

### DIFF
--- a/contracts/Core/AssetManager.sol
+++ b/contracts/Core/AssetManager.sol
@@ -63,7 +63,7 @@ contract AssetManager is ACL, AssetStorage, Constants, StateManager {
         int8 power,
         string calldata selector,
         string calldata url
-    ) external onlyRole(ASSET_MODIFIER_ROLE) notCommitState(State.Commit, parameters.epochLength()) {
+    ) external onlyRole(ASSET_MODIFIER_ROLE) notState(State.Commit, parameters.epochLength()) {
         require(jobs[jobID].assetType == uint8(AssetTypes.Job), "Job ID not present");
 
         uint32 epoch = parameters.getEpoch();
@@ -140,7 +140,7 @@ contract AssetManager is ACL, AssetStorage, Constants, StateManager {
     function addJobToCollection(uint8 collectionID, uint8 jobID)
         external
         onlyRole(ASSET_MODIFIER_ROLE)
-        notCommitState(State.Commit, parameters.epochLength())
+        notState(State.Commit, parameters.epochLength())
     {
         require(collections[collectionID].assetType == uint8(AssetTypes.Collection), "Collection ID not present");
 
@@ -172,7 +172,7 @@ contract AssetManager is ACL, AssetStorage, Constants, StateManager {
     function removeJobFromCollection(uint8 collectionID, uint8 jobIDIndex)
         external
         onlyRole(ASSET_MODIFIER_ROLE)
-        notCommitState(State.Commit, parameters.epochLength())
+        notState(State.Commit, parameters.epochLength())
     {
         require(collections[collectionID].assetType == uint8(AssetTypes.Collection), "Collection ID not present");
 
@@ -200,7 +200,10 @@ contract AssetManager is ACL, AssetStorage, Constants, StateManager {
         uint8 collectionID,
         uint32 aggregationMethod,
         int8 power
-    ) external onlyRole(ASSET_MODIFIER_ROLE) {
+    ) external
+      onlyRole(ASSET_MODIFIER_ROLE)
+      notState(State.Commit, parameters.epochLength()) 
+      {
         require(collections[collectionID].assetType == uint8(AssetTypes.Collection), "Collection ID not present");
         require(collections[collectionID].active, "Collection is inactive");
 

--- a/contracts/Core/AssetManager.sol
+++ b/contracts/Core/AssetManager.sol
@@ -200,10 +200,7 @@ contract AssetManager is ACL, AssetStorage, Constants, StateManager {
         uint8 collectionID,
         uint32 aggregationMethod,
         int8 power
-    ) external
-      onlyRole(ASSET_MODIFIER_ROLE)
-      notState(State.Commit, parameters.epochLength()) 
-      {
+    ) external onlyRole(ASSET_MODIFIER_ROLE) notState(State.Commit, parameters.epochLength()) {
         require(collections[collectionID].assetType == uint8(AssetTypes.Collection), "Collection ID not present");
         require(collections[collectionID].active, "Collection is inactive");
 

--- a/contracts/Core/StateManager.sol
+++ b/contracts/Core/StateManager.sol
@@ -18,7 +18,7 @@ contract StateManager is Constants {
         _;
     }
 
-    modifier notCommitState(State state, uint32 epochLength) {
+    modifier notState(State state, uint32 epochLength) {
         require(state != getState(epochLength), "incorrect state");
         _;
     }

--- a/test/AssetManager.js
+++ b/test/AssetManager.js
@@ -281,18 +281,21 @@ describe('AssetManager', function () {
       assertRevert(tx, 'Collection is inactive');
     });
 
-    it('updateJob, addJobToCollection, removeJobFromCollection should not work in commit state', async function () {
+    it('updateJob, updateCollection, addJobToCollection, removeJobFromCollection should not work in commit state', async function () {
       await mineToNextState(); // confirm
       await mineToNextState(); // commit
 
-      const tx = assetManager.updateJob(5, 4, 'selector/6', 'http://testurl.com/6');
-      assertRevert(tx, 'incorrect state');
-
-      const tx1 = assetManager.addJobToCollection(3, 1);
+      const tx1 = assetManager.updateJob(5, 4, 'selector/6', 'http://testurl.com/6');
       assertRevert(tx1, 'incorrect state');
 
-      const tx2 = assetManager.removeJobFromCollection(5, 4);
+      const tx2 = assetManager.updateCollection(3, 2, 5);
       assertRevert(tx2, 'incorrect state');
+
+      const tx3 = assetManager.addJobToCollection(3, 1);
+      assertRevert(tx3, 'incorrect state');
+
+      const tx4 = assetManager.removeJobFromCollection(5, 4);
+      assertRevert(tx4, 'incorrect state');
     });
     // it('should be able to get result using proxy', async function () {
     //  await delegator.upgradeDelegate(assetManager.address);


### PR DESCRIPTION
fixes #386 

The modifier name in state manager has been changed to notState form notCommitState and it has been now added in update collection.