### PR TITLE
Should not snitch more than once on any staker for same mal activity 

### DIFF
--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -357,7 +357,7 @@ describe('VoteManager', function () {
         const stakeBeforeAcc4 = (await stakeManager.stakers(stakerIdAcc4)).stake;
 
         const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
-
+        await parameters.setSlashPenaltyNum(5000);
         await voteManager.connect(signers[10]).snitch(epoch, votes,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
           signers[4].address);
@@ -365,6 +365,17 @@ describe('VoteManager', function () {
         const slashPenaltyAmount = (stakeBeforeAcc4.mul((await parameters.slashPenaltyNum()))).div(await parameters.slashPenaltyDenom());
         assertBNEqual((await stakeManager.stakers(stakerIdAcc4)).stake, stakeBeforeAcc4.sub(slashPenaltyAmount), 'stake should be less by slashPenalty');
         assertBNEqual(stakeAcc10, slashPenaltyAmount.div('2'), 'the bounty hunter should receive half of the slashPenaltyAmount of account 4');
+      });
+
+      it('staker should not be snitched on multiple times for same mal activity irrespective of slashPenalty', async function () {
+        const epoch = await getEpoch();
+
+        const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
+        const tx = voteManager.connect(signers[10]).snitch(epoch, votes,
+          '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
+          signers[4].address);
+        await parameters.setSlashPenaltyNum(10000); // Restoring the slashPenaltyNum again
+        await assertRevert(tx, 'incorrect secret/value');
       });
 
       it('staker should not be able to snitch from himself', async function () {


### PR DESCRIPTION
Fixes #413 
This is not an issue because if anyone calls snitch on any staker than the commitmentHash is set to zero for that staker.
(https://github.com/razor-network/contracts/blob/c248922e0e72e8c69a7df357e1eac17497afe3ab/contracts/Core/VoteManager.sol#L103) 

Now, if anyone calls snitch the second time on same staker than it will revert from here 
(https://github.com/razor-network/contracts/blob/c248922e0e72e8c69a7df357e1eac17497afe3ab/contracts/Core/VoteManager.sol#L101)
as require condition fails.