### PR TITLE
Added Weights for Jobs

### DIFF
--- a/contracts/Core/AssetManager.sol
+++ b/contracts/Core/AssetManager.sol
@@ -11,18 +11,7 @@ import "./ACL.sol";
 contract AssetManager is ACL, AssetStorage, Constants, StateManager, IAssetManager {
     IParameters public parameters;
 
-    event JobCreated(
-        uint8 id,
-        JobSelectorType selectorType,
-        uint8 weight,
-        int8 power,
-        address creator,
-        uint32 epoch,
-        uint256 timestamp,
-        string name,
-        string selector,
-        string url
-    );
+    event JobCreated(Structs.Job job, uint256 timestamp);
 
     event JobUpdated(
         uint8 id,
@@ -91,7 +80,7 @@ contract AssetManager is ACL, AssetStorage, Constants, StateManager, IAssetManag
             url
         );
 
-        emit JobCreated(numAssets, selectorType, weight, power, msg.sender, epoch, block.timestamp, name, selector, url);
+        emit JobCreated(jobs[numAssets], block.timestamp);
     }
 
     function updateJob(

--- a/contracts/Core/interface/IAssetManager.sol
+++ b/contracts/Core/interface/IAssetManager.sol
@@ -10,6 +10,7 @@ interface IAssetManager {
         returns (
             bool active,
             uint8 selectorType,
+            uint8 weight,
             int8 power,
             string memory name,
             string memory selector,

--- a/contracts/Delegator.sol
+++ b/contracts/Delegator.sol
@@ -20,6 +20,7 @@ contract Delegator is ACL {
         returns (
             bool active,
             uint8 selectorType,
+            uint8 weight,
             int8 power,
             string memory name,
             string memory selector,

--- a/contracts/lib/Structs.sol
+++ b/contracts/lib/Structs.sol
@@ -46,8 +46,9 @@ library Structs {
     struct Job {
         bool active;
         uint8 id;
-        uint8 assetType;
-        uint8 selectorType;
+        uint8 assetType; // 0-1
+        uint8 selectorType; // 0-1
+        uint8 weight; // 1-100
         int8 power;
         uint32 epoch;
         address creator;

--- a/test/ACL.js
+++ b/test/ACL.js
@@ -205,54 +205,54 @@ describe('Access Control Test', async () => {
 
   it('createJob() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1'), expectedRevertMessage);
   });
 
   it('createJob() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.createJob(0, 0, 'http://testurl.com/2', 'selector/2', 'test2'), expectedRevertMessage);
+    await assertRevert(assetManager.createJob(25, 0, 0, 'http://testurl.com/2', 'selector/2', 'test2'), expectedRevertMessage);
   });
 
   it('updateJob() should not be accessable by anyone besides AssetCreator', async () => {
     // Checking if Anyone can access it
-    await assertRevert(assetManager.updateJob(1, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 25, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
 
     // Checking if BlockConfirmer can access it
     await assetManager.grantRole(BLOCK_CONFIRMER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 25, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
 
     // Checking if StakeModifier can access it
     await assetManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 25, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
 
     // Checking if StakerActivityUpdater can access it
     await assetManager.grantRole(STAKER_ACTIVITY_UPDATER_ROLE, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 25, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
   });
 
   it('updateJob() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
     await mineToNextState();
-    await assetManager.updateJob(1, 2, 0, 'http://testurl.com/2', 'selector/2');
+    await assetManager.updateJob(1, 25, 2, 0, 'http://testurl.com/2', 'selector/2');
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
-    await assertRevert(assetManager.updateJob(1, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
+    await assertRevert(assetManager.updateJob(1, 25, 2, 0, 'http://testurl.com/2', 'selector/2'), expectedRevertMessage);
   });
 
   it('setAssetStatus() should not be accessable by anyone besides AssetCreator', async () => {
@@ -275,7 +275,7 @@ describe('Access Control Test', async () => {
   it('setAssetStatus() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
     await mineToNextState();
     await mineToNextState();
     await mineToNextState();
@@ -305,8 +305,8 @@ describe('Access Control Test', async () => {
   it('createCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
-    await assetManager.createJob(0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
     await mineToNextState();// reveal
     await mineToNextState();// propose
     await mineToNextState();// dispute
@@ -336,14 +336,14 @@ describe('Access Control Test', async () => {
   it('addJobToCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
-    await assetManager.createJob(0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
     await mineToNextState();// reveal
     await mineToNextState();// propose
     await mineToNextState();// dispute
     await mineToNextState();// confirm
     await assetManager.createCollection([1, 2], 1, 0, 'test');
-    await assetManager.createJob(0, 0, 'http://testurl.com/3', 'selector/3', 'test3');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/3', 'selector/3', 'test3');
     await assetManager.addJobToCollection(3, 4);
     await assetManager.revokeRole(assetCreatorHash, signers[0].address);
     await assertRevert(assetManager.addJobToCollection(3, 4), expectedRevertMessage);
@@ -369,8 +369,8 @@ describe('Access Control Test', async () => {
   it('removeJobFromCollection() should be accessable by only AssetCreator', async () => {
     const assetCreatorHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetCreatorHash, signers[0].address);
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
-    await assetManager.createJob(0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
     await mineToNextState();// reveal
     await mineToNextState();// propose
     await mineToNextState();// dispute
@@ -402,8 +402,8 @@ describe('Access Control Test', async () => {
     const assetModifierHash = ASSET_MODIFIER_ROLE;
     await assetManager.grantRole(assetModifierHash, signers[0].address);
 
-    await assetManager.createJob(0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
-    await assetManager.createJob(0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/1', 'selector/1', 'test1');
+    await assetManager.createJob(25, 0, 0, 'http://testurl.com/2', 'selector/2', 'test2');
     await mineToNextState();// reveal
     await mineToNextState();// propose
     await mineToNextState();// dispute

--- a/test/AssetManager.js
+++ b/test/AssetManager.js
@@ -38,7 +38,8 @@ describe('AssetManager', function () {
       const selectorType = 0;
       const name = 'testJSON';
       const power = -2;
-      await assetManager.createJob(power, selectorType, name, selector, url);
+      const weight = 50;
+      await assetManager.createJob(weight, power, selectorType, name, selector, url);
       const job = await assetManager.jobs(1);
       assert(job.url === url);
       assert(job.selector === selector);
@@ -54,7 +55,8 @@ describe('AssetManager', function () {
       const selectorType = 1;
       const name = 'testXHTML';
       const power = 2;
-      await assetManager.createJob(power, selectorType, name, selector, url);
+      const weight = 50;
+      await assetManager.createJob(weight, power, selectorType, name, selector, url);
       const job = await assetManager.jobs(2);
       assert(job.url === url);
       assert(job.selector === selector);
@@ -87,7 +89,8 @@ describe('AssetManager', function () {
       const selectorType = 0;
       const name = 'test3';
       const power = -6;
-      await assetManager.createJob(power, selectorType, name, selector, url);
+      const weight = 50;
+      await assetManager.createJob(weight, power, selectorType, name, selector, url);
 
       await assetManager.addJobToCollection(3, 4);
       const collection = await assetManager.getCollection(3);
@@ -115,8 +118,8 @@ describe('AssetManager', function () {
     });
 
     it('should be able to update Job', async function () {
-      await assetManager.createJob(6, 0, 'test4', 'selector/4', 'http://testurl.com/4');
-      await assetManager.updateJob(5, 4, 0, 'selector/5', 'http://testurl.com/5');
+      await assetManager.createJob(50, 6, 0, 'test4', 'selector/4', 'http://testurl.com/4');
+      await assetManager.updateJob(5, 50, 4, 0, 'selector/5', 'http://testurl.com/5');
       const job = await assetManager.jobs(5);
       assert(job.url === 'http://testurl.com/5');
       assert(job.selector === 'selector/5');
@@ -201,7 +204,7 @@ describe('AssetManager', function () {
     });
 
     it('should not be able to update job if job does not exist', async function () {
-      const tx = assetManager.updateJob(9, 2, 0, 'http://testurl.com/4', 'selector/4');
+      const tx = assetManager.updateJob(9, 50, 2, 0, 'http://testurl.com/4', 'selector/4');
       await assertRevert(tx, 'Job ID not present');
     });
 
@@ -309,7 +312,7 @@ describe('AssetManager', function () {
     it('updateJob, updateCollection, addJobToCollection, removeJobFromCollection should not work in commit state', async function () {
       await mineToNextEpoch();
 
-      const tx = assetManager.updateJob(5, 4, 0, 'selector/6', 'http://testurl.com/6');
+      const tx = assetManager.updateJob(5, 50, 4, 0, 'selector/6', 'http://testurl.com/6');
       assertRevert(tx, 'incorrect state');
 
       const tx1 = assetManager.addJobToCollection(3, 1);
@@ -352,6 +355,13 @@ describe('AssetManager', function () {
       assertBNEqual(await assetManager.getNumActiveAssets(), toBigNumber('6'), 'collection has been added again');
       await assetManager.setAssetStatus(false, 7);
       assertBNEqual(await assetManager.getNumActiveAssets(), toBigNumber('6'), 'collection has been removed again');
+    });
+
+    it('Should not be able to set Weight of job beyond max : 100', async function () {
+      const tx0 = assetManager.createJob(125, 0, 0, 'testName', 'testSelector', 'http://testurl.com/5');
+      const tx1 = assetManager.updateJob(5, 125, 0, 0, 'testSelector', 'http://testurl.com/5');
+      assertRevert(tx0, 'Weight beyond max');
+      assertRevert(tx1, 'Weight beyond max');
     });
     // it('should be able to get result using proxy', async function () {
     //  await delegator.upgradeDelegate(assetManager.address);

--- a/test/BlockManager.js
+++ b/test/BlockManager.js
@@ -100,8 +100,9 @@ describe('BlockManager', function () {
       const name = 'test';
       const power = -2;
       const selectorType = 0;
+      const weight = 50;
       let i = 0;
-      while (i < 9) { await assetManager.createJob(power, selectorType, name, selector, url); i++; }
+      while (i < 9) { await assetManager.createJob(weight, power, selectorType, name, selector, url); i++; }
 
       await mineToNextEpoch();
       await razor.transfer(signers[5].address, tokenAmount('423000'));

--- a/test/StakeManager.js
+++ b/test/StakeManager.js
@@ -90,8 +90,9 @@ describe('StakeManager', function () {
       const selectorType = 0;
       const name = 'test';
       const power = -2;
+      const weight = 50;
       let i = 0;
-      while (i < 9) { await assetManager.createJob(power, selectorType, name, selector, url); i++; }
+      while (i < 9) { await assetManager.createJob(weight, power, selectorType, name, selector, url); i++; }
 
       while (Number(await parameters.getState()) !== 4) { await mineToNextState(); }
 

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -76,8 +76,9 @@ describe('VoteManager', function () {
         const selectorType = 0;
         const name = 'test';
         const power = -2;
+        const weight = 50;
         let i = 0;
-        while (i < 9) { await assetManager.createJob(power, selectorType, name, selector, url); i++; }
+        while (i < 9) { await assetManager.createJob(weight, power, selectorType, name, selector, url); i++; }
 
         while (Number(await parameters.getState()) !== 4) { await mineToNextState(); }
 


### PR DESCRIPTION
Fixes #435 

With this PR we have added weights to job 

so now whenever the client proposes a median for collection  
they have to do weighted median
```
j1v*j1w + j2v*j2w + j2v*j2w ....
----------------------------------------
	j1w + j2w + j3w...

j(i)v = value of ith job
j(i)w = weight of ith job
````

on setting the weight of the job, have kept condition of max 100,
it's true that value is added in the numerator as well as deno, so one can say there wont be an issue.
it's for setting up limit
lets say
I have assets with weights 30,40,90 as weights 
when you add a new asset in this collection you add it with considering 100 as max, so there is a defined limit
you cant add it with 900 or something, which would dilute other weights