### PR TITLE
Bounty customized, Burn removed

### DIFF
--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -16,6 +16,8 @@ contract Parameters is ACL, Constants, IParameters {
     uint16 public override penaltyNotRevealDenom = 10000;
     uint16 public override slashPenaltyNum = 10000;
     uint16 public override slashPenaltyDenom = 10000;
+    uint16 public override bountyNum = 500; // by 20, 5 %
+    uint16 public override bountyDenom = 10000;
     uint16 public override epochLength = 300;
     uint16 public override exposureDenominator = 1000;
     uint16 public override gracePeriod = 8;
@@ -46,6 +48,16 @@ contract Parameters is ACL, Constants, IParameters {
     function setSlashPenaltyDenom(uint16 _slashPenaltyDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit ParameterChanged(msg.sender, "slashPenaltyDenom", slashPenaltyDenom, _slashPenaltyDenominator, block.timestamp);
         slashPenaltyDenom = _slashPenaltyDenominator;
+    }
+
+    function setBountyNum(uint16 _bountyNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "bountyNum", bountyNum, _bountyNum, block.timestamp);
+        bountyNum = _bountyNum;
+    }
+
+    function setBountyDenom(uint16 _bountyDenom) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "bountyDenom", bountyDenom, _bountyDenom, block.timestamp);
+        bountyDenom = _bountyDenom;
     }
 
     function setWithdrawLockPeriod(uint8 _withdrawLockPeriod) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -120,5 +132,13 @@ contract Parameters is ACL, Constants, IParameters {
     function getState() external view override returns (uint8) {
         uint8 state = uint8(((block.number) / (epochLength / NUM_STATES)) % (NUM_STATES));
         return (state);
+    }
+
+    function getSlashNumDenom() external view override returns (uint16, uint16) {
+        return (slashPenaltyNum, slashPenaltyDenom);
+    }
+
+    function getBountyNumDenom() external view override returns (uint16, uint16) {
+        return (bountyNum, bountyDenom);
     }
 }

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -6,6 +6,10 @@ interface IParameters {
 
     function getState() external view returns (uint8);
 
+    function getSlashNumDenom() external view returns (uint16, uint16);
+
+    function getBountyNumDenom() external view returns (uint16, uint16);
+
     function epochLength() external view returns (uint16);
 
     function minStake() external view returns (uint256);
@@ -19,6 +23,10 @@ interface IParameters {
     function penaltyNotRevealNum() external view returns (uint16);
 
     function penaltyNotRevealDenom() external view returns (uint16);
+
+    function bountyNum() external view returns (uint16);
+
+    function bountyDenom() external view returns (uint16);
 
     function maxCommission() external view returns (uint8);
 

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -366,12 +366,14 @@ describe('VoteManager', function () {
         const slashPenaltyAmount = (stakeBeforeAcc4.mul((await parameters.slashPenaltyNum()))).div(await parameters.slashPenaltyDenom());
         assertBNEqual((await stakeManager.stakers(stakerIdAcc4)).stake, stakeBeforeAcc4.sub(slashPenaltyAmount), 'stake should be less by slashPenalty');
 
+        const bounty = (slashPenaltyAmount.mul(await parameters.bountyNum())).div(await parameters.bountyDenom());
+        assertBNEqual(bounty, slashPenaltyAmount.div(toBigNumber('20'))); // To check if contract calculation is working as expected
         // Bounty should be locked
         const bountyLock = await stakeManager.bountyLocks(toBigNumber('1'));
         assertBNEqual(await stakeManager.bountyCounter(), toBigNumber('1'));
         assertBNEqual(bountyLock.bountyHunter, signers[10].address);
         assertBNEqual(bountyLock.redeemAfter, epoch + WITHDRAW_LOCK_PERIOD);
-        assertBNEqual(bountyLock.amount, slashPenaltyAmount.div(toBigNumber('2')));
+        assertBNEqual(bountyLock.amount, bounty);
       });
 
       it('staker should not be snitched on multiple times for same mal activity irrespective of slashPenalty', async function () {
@@ -676,10 +678,11 @@ describe('VoteManager', function () {
         // Bounty should be locked
         const bountyId = await stakeManager.bountyCounter();
         const bountyLock = await stakeManager.bountyLocks(bountyId);
+        const bounty = (slashPenaltyAmount.mul(await parameters.bountyNum())).div(await parameters.bountyDenom());
         epoch = await getEpoch();
         assertBNEqual(bountyLock.bountyHunter, signers[10].address);
         assertBNEqual(bountyLock.redeemAfter, epoch + WITHDRAW_LOCK_PERIOD);
-        assertBNEqual(bountyLock.amount, slashPenaltyAmount.div(toBigNumber('2')));
+        assertBNEqual(bountyLock.amount, bounty);
 
         // Anyone shouldnt be able to redeem someones elses bounty
         const tx = stakeManager.connect(signers[8]).redeemBounty(bountyId);
@@ -696,7 +699,7 @@ describe('VoteManager', function () {
         // Should able to redeem
         await stakeManager.connect(signers[10]).redeemBounty(bountyId);
         const balanceAfterAcc10 = await razor.balanceOf(signers[10].address);
-        assertBNEqual(balanceAfterAcc10, balanceBeforeAcc10.add(slashPenaltyAmount.div('2')),
+        assertBNEqual(balanceAfterAcc10, balanceBeforeAcc10.add(bounty),
           'the bounty hunter should receive half of the slashPenaltyAmount of account 4');
 
         // Should not able to redeem again


### PR DESCRIPTION
Fixes #389 

Have made penalty divider customizable 
Earlier it was 2 

so ```slashPenalty/2``` was awarded 
now its ```slashPenalty * bountyNum / bountyDenom```

have kept bountyNum = 500
bontyDenom = 10000

so at last its slashPenalty/20 , 5 %

remaining 95% stays in contract