### PR TITLE
Customised Bounty and Amount to be burned

### DIFF
--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -16,6 +16,8 @@ contract Parameters is ACL, Constants, IParameters {
     uint16 public override penaltyNotRevealDenom = 10000;
     uint16 public override slashPenaltyNum = 10000;
     uint16 public override slashPenaltyDenom = 10000;
+    uint16 public override bountyNum = 500; // by 20, 5 %
+    uint16 public override bountyDenom = 10000;
     uint16 public override epochLength = 300;
     uint16 public override exposureDenominator = 1000;
     uint16 public override gracePeriod = 8;
@@ -46,6 +48,16 @@ contract Parameters is ACL, Constants, IParameters {
     function setSlashPenaltyDenom(uint16 _slashPenaltyDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit ParameterChanged(msg.sender, "slashPenaltyDenom", slashPenaltyDenom, _slashPenaltyDenominator, block.timestamp);
         slashPenaltyDenom = _slashPenaltyDenominator;
+    }
+
+    function setBountyNum(uint16 _bountyNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "bountyNum", bountyNum, _bountyNum, block.timestamp);
+        bountyNum = _bountyNum;
+    }
+
+    function setBountyDenom(uint16 _bountyDenom) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "bountyDenom", bountyDenom, _bountyDenom, block.timestamp);
+        bountyDenom = _bountyDenom;
     }
 
     function setWithdrawLockPeriod(uint8 _withdrawLockPeriod) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -120,5 +132,13 @@ contract Parameters is ACL, Constants, IParameters {
     function getState() external view override returns (uint8) {
         uint8 state = uint8(((block.number) / (epochLength / NUM_STATES)) % (NUM_STATES));
         return (state);
+    }
+
+    function getSlashNumDenom() external view override returns (uint16, uint16) {
+        return (slashPenaltyNum, slashPenaltyDenom);
+    }
+
+    function getBountyNumDenom() external view override returns (uint16, uint16) {
+        return (bountyNum, bountyDenom);
     }
 }

--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -18,6 +18,8 @@ contract Parameters is ACL, Constants, IParameters {
     uint16 public override slashPenaltyDenom = 10000;
     uint16 public override bountyNum = 500; // by 20, 5 %
     uint16 public override bountyDenom = 10000;
+    uint16 public override burnSlashNum = 10000; // 100 %
+    uint16 public override burnSlashDenom = 10000;
     uint16 public override epochLength = 300;
     uint16 public override exposureDenominator = 1000;
     uint16 public override gracePeriod = 8;
@@ -48,6 +50,16 @@ contract Parameters is ACL, Constants, IParameters {
     function setSlashPenaltyDenom(uint16 _slashPenaltyDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit ParameterChanged(msg.sender, "slashPenaltyDenom", slashPenaltyDenom, _slashPenaltyDenominator, block.timestamp);
         slashPenaltyDenom = _slashPenaltyDenominator;
+    }
+
+    function setBurnSlashNum(uint16 _burnSlashNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "burnSlashNum", burnSlashNum, _burnSlashNum, block.timestamp);
+        burnSlashNum = _burnSlashNum;
+    }
+
+    function setBurnSlashDenom(uint16 _burnSlashDenom) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "burnSlashDenom", burnSlashDenom, _burnSlashDenom, block.timestamp);
+        burnSlashDenom = _burnSlashDenom;
     }
 
     function setBountyNum(uint16 _bountyNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -132,13 +144,5 @@ contract Parameters is ACL, Constants, IParameters {
     function getState() external view override returns (uint8) {
         uint8 state = uint8(((block.number) / (epochLength / NUM_STATES)) % (NUM_STATES));
         return (state);
-    }
-
-    function getSlashNumDenom() external view override returns (uint16, uint16) {
-        return (slashPenaltyNum, slashPenaltyDenom);
-    }
-
-    function getBountyNumDenom() external view override returns (uint16, uint16) {
-        return (bountyNum, bountyDenom);
     }
 }

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -310,7 +310,7 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause, 
         bountyCounter = bountyCounter + 1;
         bountyLocks[bountyCounter] = Structs.BountyLock(bountyHunter, bounty, epoch + (parameters.withdrawLockPeriod()));
 
-        uint256 amountToBeBurned = ((slashPenaltyAmount - bounty) * parameters.burnSlashNum())/ parameters.burnSlashDenom();
+        uint256 amountToBeBurned = ((slashPenaltyAmount - bounty) * parameters.burnSlashNum()) / parameters.burnSlashDenom();
 
         //please note that since slashing is a critical part of consensus algorithm,
         //the following transfers are not `reuquire`d. even if the transfers fail, the slashing

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -6,10 +6,6 @@ interface IParameters {
 
     function getState() external view returns (uint8);
 
-    function getSlashNumDenom() external view returns (uint16, uint16);
-
-    function getBountyNumDenom() external view returns (uint16, uint16);
-
     function epochLength() external view returns (uint16);
 
     function minStake() external view returns (uint256);
@@ -27,6 +23,10 @@ interface IParameters {
     function bountyNum() external view returns (uint16);
 
     function bountyDenom() external view returns (uint16);
+
+    function burnSlashNum() external view returns (uint16);
+
+    function burnSlashDenom() external view returns (uint16);
 
     function maxCommission() external view returns (uint8);
 

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -6,6 +6,10 @@ interface IParameters {
 
     function getState() external view returns (uint8);
 
+    function getSlashNumDenom() external view returns (uint16, uint16);
+
+    function getBountyNumDenom() external view returns (uint16, uint16);
+
     function epochLength() external view returns (uint16);
 
     function minStake() external view returns (uint256);
@@ -19,6 +23,10 @@ interface IParameters {
     function penaltyNotRevealNum() external view returns (uint16);
 
     function penaltyNotRevealDenom() external view returns (uint16);
+
+    function bountyNum() external view returns (uint16);
+
+    function bountyDenom() external view returns (uint16);
 
     function maxCommission() external view returns (uint8);
 

--- a/test/BlockManager.js
+++ b/test/BlockManager.js
@@ -14,6 +14,7 @@ const {
   DEFAULT_ADMIN_ROLE_HASH,
   STAKE_MODIFIER_ROLE,
   ASSET_MODIFIER_ROLE,
+  BURN_ADDRESS,
   WITHDRAW_LOCK_PERIOD,
 
 } = require('./helpers/constants');
@@ -293,6 +294,7 @@ describe('BlockManager', function () {
 
       const stakerIdAccount = await stakeManager.stakerIds(signers[5].address);
       const stakeBeforeAcc5 = (await stakeManager.getStaker(stakerIdAccount)).stake;
+      const balanceBeforeBurn = await razor.balanceOf(BURN_ADDRESS);
 
       let blockId;
       let block;
@@ -320,6 +322,10 @@ describe('BlockManager', function () {
       assertBNEqual(bountyLock.bountyHunter, signers[19].address);
       assertBNEqual(bountyLock.redeemAfter, epoch + WITHDRAW_LOCK_PERIOD);
       assertBNEqual(bountyLock.amount, bounty);
+
+      // From the remaining amount, appropriate amount should be burned
+      const amountToBeBurned = ((slashPenaltyAmount.sub(bounty)).mul(await parameters.burnSlashNum())).div(await parameters.burnSlashDenom());
+      assertBNEqual(await razor.balanceOf(BURN_ADDRESS), balanceBeforeBurn.add(amountToBeBurned));
     });
 
     it('block proposed by account 6 should be confirmed', async function () {

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -366,12 +366,14 @@ describe('VoteManager', function () {
         const slashPenaltyAmount = (stakeBeforeAcc4.mul((await parameters.slashPenaltyNum()))).div(await parameters.slashPenaltyDenom());
         assertBNEqual((await stakeManager.stakers(stakerIdAcc4)).stake, stakeBeforeAcc4.sub(slashPenaltyAmount), 'stake should be less by slashPenalty');
 
+        const bounty = (slashPenaltyAmount.mul(await parameters.bountyNum())).div(await parameters.bountyDenom());
+        assertBNEqual(bounty, slashPenaltyAmount.div(toBigNumber('20'))); // To check if contract calculation is working as expected
         // Bounty should be locked
         const bountyLock = await stakeManager.bountyLocks(toBigNumber('1'));
         assertBNEqual(await stakeManager.bountyCounter(), toBigNumber('1'));
         assertBNEqual(bountyLock.bountyHunter, signers[10].address);
         assertBNEqual(bountyLock.redeemAfter, epoch + WITHDRAW_LOCK_PERIOD);
-        assertBNEqual(bountyLock.amount, slashPenaltyAmount.div(toBigNumber('2')));
+        assertBNEqual(bountyLock.amount, bounty);
       });
 
       it('staker should not be snitched on multiple times for same mal activity irrespective of slashPenalty', async function () {
@@ -676,10 +678,11 @@ describe('VoteManager', function () {
         // Bounty should be locked
         const bountyId = await stakeManager.bountyCounter();
         const bountyLock = await stakeManager.bountyLocks(bountyId);
+        const bounty = (slashPenaltyAmount.mul(await parameters.bountyNum())).div(await parameters.bountyDenom());
         epoch = await getEpoch();
         assertBNEqual(bountyLock.bountyHunter, signers[10].address);
         assertBNEqual(bountyLock.redeemAfter, epoch + WITHDRAW_LOCK_PERIOD);
-        assertBNEqual(bountyLock.amount, slashPenaltyAmount.div(toBigNumber('2')));
+        assertBNEqual(bountyLock.amount, bounty);
 
         // Anyone shouldnt be able to redeem someones elses bounty
         const tx = stakeManager.connect(signers[8]).redeemBounty(bountyId);
@@ -696,7 +699,7 @@ describe('VoteManager', function () {
         // Should able to redeem
         await stakeManager.connect(signers[10]).redeemBounty(bountyId);
         const balanceAfterAcc10 = await razor.balanceOf(signers[10].address);
-        assertBNEqual(balanceAfterAcc10, balanceBeforeAcc10.add(slashPenaltyAmount.div('2')),
+        assertBNEqual(balanceAfterAcc10, balanceBeforeAcc10.add(bounty),
           'the bounty hunter should receive half of the slashPenaltyAmount of account 4');
 
         // Should not able to redeem again


### PR DESCRIPTION
Fixes #389 

Have made penalty divider customizable
Earlier it was 2

so slashPenalty/2 was awarded
now its slashPenalty * bountyNum / bountyDenom

have kept bountyNum = 500
bontyDenom = 10000

so at last its slashPenalty/20 , 5 %

from remaining 95% amount, 
```
95% amount * burnSlashNum/burnSlashDenom
```

is burned, remaining stays is contract
