### PR TITLE
Finalize Dispute : Sorted Proposed Blocks Bug Fix

### DIFF
--- a/contracts/Core/BlockManager.sol
+++ b/contracts/Core/BlockManager.sol
@@ -68,8 +68,7 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager, IBlockM
 
         uint256 biggestInfluence = stakeManager.getInfluence(biggestInfluencerId);
         uint8 numProposedBlocks = uint8(sortedProposedBlockIds[epoch].length);
-        proposedBlocks[epoch][numProposedBlocks] = Structs.Block(proposerId, medians, iteration, biggestInfluence);
-
+        proposedBlocks[epoch][numProposedBlocks] = Structs.Block(proposerId, medians, iteration, biggestInfluence, true);
         _insertAppropriately(epoch, numProposedBlocks, iteration, biggestInfluence);
 
         emit Proposed(epoch, proposerId, medians, iteration, biggestInfluencerId, block.timestamp);
@@ -121,9 +120,9 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager, IBlockM
         require(stakerId > 0, "Structs.Staker does not exist");
         require(blocks[epoch].proposerId == 0, "Block already confirmed");
 
-        if (sortedProposedBlockIds[epoch].length == 0) return;
+        if (sortedProposedBlockIds[epoch].length == 0 || blockIndexToBeConfirmed == -1) return;
 
-        uint8 blockId = sortedProposedBlockIds[epoch][0];
+        uint8 blockId = sortedProposedBlockIds[epoch][uint8(blockIndexToBeConfirmed)];
         uint32 proposerId = proposedBlocks[epoch][blockId].proposerId;
         require(proposerId == stakerId, "Block can be confirmed by proposer of the block");
         emit BlockConfirmed(epoch, proposerId, proposedBlocks[epoch][blockId].medians, block.timestamp);
@@ -134,9 +133,8 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager, IBlockM
 
     function confirmPreviousEpochBlock(uint32 stakerId) external override initialized onlyRole(BLOCK_CONFIRMER_ROLE) {
         uint32 epoch = parameters.getEpoch();
-        if (sortedProposedBlockIds[epoch - 1].length == 0) return;
-
-        uint8 blockId = sortedProposedBlockIds[epoch - 1][0];
+        if (sortedProposedBlockIds[epoch - 1].length == 0 || blockIndexToBeConfirmed == -1) return;
+        uint8 blockId = sortedProposedBlockIds[epoch - 1][uint8(blockIndexToBeConfirmed)];
         blocks[epoch - 1] = proposedBlocks[epoch - 1][blockId];
 
         emit BlockConfirmed(
@@ -162,16 +160,31 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager, IBlockM
         );
         uint32 median = uint32(disputes[epoch][msg.sender].accProd / disputes[epoch][msg.sender].accWeight);
         require(median > 0, "median can not be zero");
-        uint8 assetId = disputes[epoch][msg.sender].assetId;
         uint8 blockId = sortedProposedBlockIds[epoch][blockIndex];
+        require(proposedBlocks[epoch][blockId].valid, "Block already has been disputed");
+        uint8 assetId = disputes[epoch][msg.sender].assetId;
         uint8 assetIndex = assetManager.getAssetIndex(assetId);
         require(
             proposedBlocks[epoch][blockId].medians[assetIndex - 1] != median,
             "Proposed Alternate block is identical to proposed block"
         );
         uint8 numProposedBlocks = uint8(sortedProposedBlockIds[epoch].length);
-        sortedProposedBlockIds[epoch][blockIndex] = sortedProposedBlockIds[epoch][numProposedBlocks - 1];
-        sortedProposedBlockIds[epoch].pop();
+
+        proposedBlocks[epoch][blockId].valid = false;
+
+        if (uint8(blockIndexToBeConfirmed) == blockIndex) {
+            // If the chosen one only is the culprit one, find successor
+            // O(maxAltBlocks)
+
+            blockIndexToBeConfirmed = -1;
+            for (uint8 i = blockIndex + 1; i < numProposedBlocks; i++) {
+                uint8 _blockId = sortedProposedBlockIds[epoch][i];
+                if (proposedBlocks[epoch][_blockId].valid) {
+                    blockIndexToBeConfirmed = int8(i);
+                    break;
+                }
+            }
+        }
 
         uint32 proposerId = proposedBlocks[epoch][blockId].proposerId;
         return stakeManager.slash(epoch, proposerId, msg.sender);
@@ -239,6 +252,7 @@ contract BlockManager is Initializable, ACL, BlockStorage, StateManager, IBlockM
     ) internal {
         if (sortedProposedBlockIds[epoch].length == 0) {
             sortedProposedBlockIds[epoch].push(0);
+            blockIndexToBeConfirmed = 0;
             return;
         }
 

--- a/contracts/Core/storage/BlockStorage.sol
+++ b/contracts/Core/storage/BlockStorage.sol
@@ -9,6 +9,8 @@ contract BlockStorage {
     mapping(uint32 => mapping(uint8 => Structs.Block)) public proposedBlocks;
     //epoch->blockId
     mapping(uint32 => uint8[]) public sortedProposedBlockIds;
+
+    int8 public blockIndexToBeConfirmed; // Index in sortedProposedBlockIds
     // epoch -> blocks
     mapping(uint32 => Structs.Block) public blocks;
 }

--- a/contracts/lib/Structs.sol
+++ b/contracts/lib/Structs.sol
@@ -39,6 +39,7 @@ library Structs {
         uint32[] medians;
         uint256 iteration;
         uint256 biggestInfluence;
+        bool valid;
     }
 
     struct Dispute {

--- a/test/BlockManager.js
+++ b/test/BlockManager.js
@@ -362,7 +362,7 @@ describe('BlockManager', function () {
       assertRevert(tx2, 'Incorrect Caller');
     });
 
-    it('all blocks being disputed', async function () {
+    it('all blocks being disputed and should not able to dispute same block again', async function () {
       await mineToNextEpoch();
 
       await razor.connect(signers[0]).transfer(signers[7].address, tokenAmount('20000'));
@@ -451,6 +451,9 @@ describe('BlockManager', function () {
 
       await blockManager.connect(signers[19]).finalizeDispute(epoch, 0);
 
+      const tx = blockManager.connect(signers[19]).finalizeDispute(epoch, 0);
+
+      assertRevert(tx, 'Block already has been disputed');
       const res2 = await calculateDisputesData(12,
         voteManager,
         stakeManager,
@@ -465,7 +468,7 @@ describe('BlockManager', function () {
       assertBNEqual(secondDispute.accWeight, res2.totalInfluenceRevealed, 'totalInfluenceRevealed should match');
       assertBNEqual(secondDispute.lastVisitedStaker, res2.sortedStakers[res2.sortedStakers.length - 1], 'lastVisited should match');
 
-      await blockManager.connect(signers[15]).finalizeDispute(epoch, 0);
+      await blockManager.connect(signers[15]).finalizeDispute(epoch, 1);
       // assertBNEqual(secondDispute2.median, res2.median, 'median should match');
       // assert((await proposedBlock.valid) === false);
     });
@@ -1300,6 +1303,88 @@ describe('BlockManager', function () {
       await blockManager.connect(signers[12]).claimBlockReward();
       staker = await stakeManager.getStaker(stakerIdAcc12);
       assertBNEqual(staker.stake, stake);
+    });
+
+    it('BlockToBeConfirmed should always have lowest iteration and should be valid', async function () {
+      await mineToNextEpoch();
+      const epoch = await getEpoch();
+      const base = 14;
+
+      for (let i = 0; i < 4; i++) { // i=2 since [base+1] has already staked
+        await razor.transfer(signers[base + i].address, tokenAmount('420000'));
+        await razor.connect(signers[base + i]).approve(stakeManager.address, tokenAmount('420000'));
+        await stakeManager.connect(signers[base + i]).stake(epoch, tokenAmount('420000'));
+      }
+
+      const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
+      const commitment = utils.solidityKeccak256(
+        ['uint32', 'uint48[]', 'bytes32'],
+        [epoch, votes, '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd']
+      );
+
+      for (let i = 0; i < 4; i++) {
+        await voteManager.connect(signers[base + i]).commit(epoch, commitment);
+      }
+
+      await mineToNextState(); // reveal
+
+      for (let i = 0; i < 4; i++) {
+        await voteManager.connect(signers[base + i]).reveal(epoch, votes,
+          '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd');
+      }
+
+      await mineToNextState(); // propose state
+
+      const { biggestInfluence, biggestInfluencerId } = await getBiggestInfluenceAndId(stakeManager);
+      let iteration;
+      for (let i = 0; i < 4; i++) {
+        const stakerIdAcc = await stakeManager.stakerIds(signers[base + i].address);
+        const staker = await stakeManager.getStaker(stakerIdAcc);
+        iteration = await getIteration(voteManager, stakeManager, staker, biggestInfluence);
+        await blockManager.connect(signers[base + i]).propose(epoch,
+          [100, 201, 300, 400, 500, 600, 700, 800, 900],
+          iteration,
+          biggestInfluencerId);
+      }
+
+      await mineToNextState(); // dispute state
+      // okay so now we have 4 invalid blcoks
+      // lets say sortedProposedBlockId is [A,B,C,D]
+      let blockIndexToBeConfirmed = await blockManager.blockIndexToBeConfirmed();
+      //  should be 0
+      assertBNEqual(blockIndexToBeConfirmed, toBigNumber('0'));
+
+      // we dispute A - 0
+      const res = await calculateDisputesData(11,
+        voteManager,
+        stakeManager,
+        assetManager,
+        epoch);
+
+      await blockManager.giveSorted(epoch, 11, res.sortedStakers);
+
+      await blockManager.finalizeDispute(epoch, 0);
+      blockIndexToBeConfirmed = await blockManager.blockIndexToBeConfirmed();
+      // should be 1
+      assertBNEqual(blockIndexToBeConfirmed, toBigNumber('1'));
+
+      // we dispute C - 2
+      await blockManager.finalizeDispute(epoch, 2);
+      blockIndexToBeConfirmed = await blockManager.blockIndexToBeConfirmed();
+      // should not change, be 1 only
+      assertBNEqual(blockIndexToBeConfirmed, toBigNumber('1'));
+
+      // we dispute B - 1
+      await blockManager.finalizeDispute(epoch, 1);
+      blockIndexToBeConfirmed = await blockManager.blockIndexToBeConfirmed();
+      // should change to 3
+      assertBNEqual(blockIndexToBeConfirmed, toBigNumber('3'));
+
+      // we dispute D - 3
+      await blockManager.finalizeDispute(epoch, 3);
+      blockIndexToBeConfirmed = await blockManager.blockIndexToBeConfirmed();
+      // should change to -1 ;
+      assertBNEqual(Number(blockIndexToBeConfirmed), -1);
     });
   });
 });


### PR DESCRIPTION
Fixes #415 
Have introduced new variable called as blockIndexToBeConfirmed
It keeps track of best block index from sortedProposedBlockIds.
Every time some one calls finalizeDispute, we check if the one with blockIndexToBeConfirmed is disputed, if yes we find next best and assign it.
Its set as -1 if all blocks are disputed. that's why its int8.