### PR TITLE
staker should be able to increase stake with n number of RZR token

### DIFF
--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -69,8 +69,8 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause, 
         checkEpochAndState(State.Commit, epoch, parameters.epochLength())
         whenNotPaused
     {
-        require(amount >= parameters.minStake(), "staked amount is less than minimum stake required");
         uint32 stakerId = stakerIds[msg.sender];
+        require(amount + stakers[stakerId].stake >= parameters.minStake(), "staked amount is less than minimum stake required");
         emit Staked(msg.sender, epoch, stakerId, stakers[stakerId].stake, block.timestamp);
 
         if (stakerId == 0) {

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -70,10 +70,10 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause, 
         whenNotPaused
     {
         uint32 stakerId = stakerIds[msg.sender];
-        require(amount + stakers[stakerId].stake >= parameters.minStake(), "staked amount is less than minimum stake required");
         emit Staked(msg.sender, epoch, stakerId, stakers[stakerId].stake, block.timestamp);
 
         if (stakerId == 0) {
+            require(amount >= parameters.minStake(), "staked amount is less than minimum stake required");
             numStakers = numStakers + (1);
             stakerId = numStakers;
             stakerIds[msg.sender] = stakerId;

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -84,6 +84,7 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause, 
             // Minting
             require(sToken.mint(msg.sender, amount, amount)); // as 1RZR = 1 sRZR
         } else {
+            require(amount + stakers[stakerId].stake >= parameters.minStake(), "staked amount is less than minimum stake required");
             IStakedToken sToken = IStakedToken(stakers[stakerId].tokenAddress);
             uint256 totalSupply = sToken.totalSupply();
             uint256 toMint = _convertRZRtoSRZR(amount, stakers[stakerId].stake, totalSupply); // RZRs to sRZRs

--- a/test/StakeManager.js
+++ b/test/StakeManager.js
@@ -1416,5 +1416,15 @@ describe('StakeManager', function () {
       staker = await stakeManager.getStaker(4);
       assertBNEqual(prevStake, staker.stake, 'Inactivity penalties have been levied');
     });
+    it('staker should be able to increase stake by any number of RZR token', async () => {
+      let staker = await stakeManager.getStaker(4);
+      const epoch = await getEpoch();
+      const amount = tokenAmount('1');
+      const prevStake = staker.stake;
+      await razor.connect(signers[4]).approve(stakeManager.address, amount);
+      await stakeManager.connect(signers[4]).stake(epoch, amount);
+      staker = await stakeManager.getStaker(4);
+      assertBNEqual(prevStake.add(amount), staker.stake, 'stakeAmount should increase');
+    });
   });
 });


### PR DESCRIPTION
Currently If staker wants to increase stake, staker needs to stake RZR tokens >= minStake. But now staker can stake any number of tokens untill amount + currentStake >= minStake.

Let Say staker A has currentStake = 990 RZR tokens, amount it want to stake is 10 RZR tokens, then staker can easily increase stake with 10 RZR tokens because it statisfies the condition. 

Fixes #459 