### PR TITLE
Bounty and amount_to_be_burned calculated directly on stake and denominator for penalty calculation made common across

### DIFF
--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -6,6 +6,11 @@ import "./ACL.sol";
 import "./storage/Constants.sol";
 
 contract Parameters is ACL, Constants, IParameters {
+    struct SlashNums
+    {   uint16 bounty;
+        uint16 burn;
+        uint16 keep; 
+    }
     uint8 public override withdrawLockPeriod = 1;
     uint8 public override maxAltBlocks = 5;
     uint8 public override aggregationRange = 3;
@@ -13,8 +18,8 @@ contract Parameters is ACL, Constants, IParameters {
     uint8 public override resetLockPenalty = 1;
     uint8 public override maxCommission = 20;
     uint16 public override penaltyNotRevealNum = 1;
-    uint16 public override bountyNum = 500; // by 20, 5 %
-    uint16 public override burnSlashNum = 9500; // 100 %
+    SlashNums public slashNums = SlashNums(500, 9500, 0);
+    // Slash Penalty = bounty + burned + kept
     uint16 public override baseDenominator = 10000;
     uint16 public override epochLength = 300;
     uint16 public override exposureDenominator = 1000;
@@ -33,14 +38,12 @@ contract Parameters is ACL, Constants, IParameters {
         penaltyNotRevealNum = _penaltyNotRevealNumerator;
     }
 
-    function setBurnSlashNum(uint16 _burnSlashNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "burnSlashNum", burnSlashNum, _burnSlashNum, block.timestamp);
-        burnSlashNum = _burnSlashNum;
-    }
-
-    function setBountyNum(uint16 _bountyNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "bountyNum", bountyNum, _bountyNum, block.timestamp);
-        bountyNum = _bountyNum;
+    function setSlashParams(uint16 _bounty, uint16 _burn, uint16 _keep) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_bounty + _burn + _keep <= 10000, "Slash nums addtion exceeds 10000");
+        emit ParameterChanged(msg.sender, "bountySlashNum", slashNums.bounty, _bounty, block.timestamp);
+        emit ParameterChanged(msg.sender, "burnSlashNum", slashNums.burn, _burn, block.timestamp);
+        emit ParameterChanged(msg.sender, "keepSlashNum", slashNums.keep, _keep, block.timestamp);
+        slashNums = SlashNums (_bounty, _burn, _keep);
     }
 
     function setBaseDenominator(uint16 _baseDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -120,5 +123,10 @@ contract Parameters is ACL, Constants, IParameters {
     function getState() external view override returns (uint8) {
         uint8 state = uint8(((block.number) / (epochLength / NUM_STATES)) % (NUM_STATES));
         return (state);
+    }
+
+    function getAllSlashParams() external view override returns (uint16,uint16,uint16, uint16)
+    {
+        return (slashNums.bounty, slashNums.burn, slashNums.keep, baseDenominator);
     }
 }

--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -13,13 +13,9 @@ contract Parameters is ACL, Constants, IParameters {
     uint8 public override resetLockPenalty = 1;
     uint8 public override maxCommission = 20;
     uint16 public override penaltyNotRevealNum = 1;
-    uint16 public override penaltyNotRevealDenom = 10000;
-    uint16 public override slashPenaltyNum = 10000;
-    uint16 public override slashPenaltyDenom = 10000;
     uint16 public override bountyNum = 500; // by 20, 5 %
-    uint16 public override bountyDenom = 10000;
-    uint16 public override burnSlashNum = 10000; // 100 %
-    uint16 public override burnSlashDenom = 10000;
+    uint16 public override burnSlashNum = 9500; // 100 %
+    uint16 public override baseDenominator = 10000;
     uint16 public override epochLength = 300;
     uint16 public override exposureDenominator = 1000;
     uint16 public override gracePeriod = 8;
@@ -37,29 +33,9 @@ contract Parameters is ACL, Constants, IParameters {
         penaltyNotRevealNum = _penaltyNotRevealNumerator;
     }
 
-    function setPenaltyNotRevealDeom(uint16 _penaltyNotRevealDenom) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "penaltyNotRevealDenom", penaltyNotRevealDenom, _penaltyNotRevealDenom, block.timestamp);
-        penaltyNotRevealDenom = _penaltyNotRevealDenom;
-    }
-
-    function setSlashPenaltyNum(uint16 _slashPenaltyNumerator) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "slashPenaltyNum", slashPenaltyNum, _slashPenaltyNumerator, block.timestamp);
-        slashPenaltyNum = _slashPenaltyNumerator;
-    }
-
-    function setSlashPenaltyDenom(uint16 _slashPenaltyDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "slashPenaltyDenom", slashPenaltyDenom, _slashPenaltyDenominator, block.timestamp);
-        slashPenaltyDenom = _slashPenaltyDenominator;
-    }
-
     function setBurnSlashNum(uint16 _burnSlashNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
         emit ParameterChanged(msg.sender, "burnSlashNum", burnSlashNum, _burnSlashNum, block.timestamp);
         burnSlashNum = _burnSlashNum;
-    }
-
-    function setBurnSlashDenom(uint16 _burnSlashDenom) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "burnSlashDenom", burnSlashDenom, _burnSlashDenom, block.timestamp);
-        burnSlashDenom = _burnSlashDenom;
     }
 
     function setBountyNum(uint16 _bountyNum) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -67,9 +43,9 @@ contract Parameters is ACL, Constants, IParameters {
         bountyNum = _bountyNum;
     }
 
-    function setBountyDenom(uint16 _bountyDenom) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        emit ParameterChanged(msg.sender, "bountyDenom", bountyDenom, _bountyDenom, block.timestamp);
-        bountyDenom = _bountyDenom;
+    function setBaseDenominator(uint16 _baseDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit ParameterChanged(msg.sender, "baseDenom", baseDenominator, _baseDenominator, block.timestamp);
+        baseDenominator = _baseDenominator;
     }
 
     function setWithdrawLockPeriod(uint8 _withdrawLockPeriod) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -43,7 +43,7 @@ contract Parameters is ACL, Constants, IParameters {
         uint16 _burn,
         uint16 _keep
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_bounty + _burn + _keep <= 10000, "Slash nums addtion exceeds 10000");
+        require(_bounty + _burn + _keep <= baseDenominator, "Slash nums addtion exceeds 10000");
         emit ParameterChanged(msg.sender, "bountySlashNum", slashNums.bounty, _bounty, block.timestamp);
         emit ParameterChanged(msg.sender, "burnSlashNum", slashNums.burn, _burn, block.timestamp);
         emit ParameterChanged(msg.sender, "keepSlashNum", slashNums.keep, _keep, block.timestamp);

--- a/contracts/Core/Parameters.sol
+++ b/contracts/Core/Parameters.sol
@@ -6,10 +6,10 @@ import "./ACL.sol";
 import "./storage/Constants.sol";
 
 contract Parameters is ACL, Constants, IParameters {
-    struct SlashNums
-    {   uint16 bounty;
+    struct SlashNums {
+        uint16 bounty;
         uint16 burn;
-        uint16 keep; 
+        uint16 keep;
     }
     uint8 public override withdrawLockPeriod = 1;
     uint8 public override maxAltBlocks = 5;
@@ -38,12 +38,16 @@ contract Parameters is ACL, Constants, IParameters {
         penaltyNotRevealNum = _penaltyNotRevealNumerator;
     }
 
-    function setSlashParams(uint16 _bounty, uint16 _burn, uint16 _keep) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setSlashParams(
+        uint16 _bounty,
+        uint16 _burn,
+        uint16 _keep
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(_bounty + _burn + _keep <= 10000, "Slash nums addtion exceeds 10000");
         emit ParameterChanged(msg.sender, "bountySlashNum", slashNums.bounty, _bounty, block.timestamp);
         emit ParameterChanged(msg.sender, "burnSlashNum", slashNums.burn, _burn, block.timestamp);
         emit ParameterChanged(msg.sender, "keepSlashNum", slashNums.keep, _keep, block.timestamp);
-        slashNums = SlashNums (_bounty, _burn, _keep);
+        slashNums = SlashNums(_bounty, _burn, _keep);
     }
 
     function setBaseDenominator(uint16 _baseDenominator) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -125,7 +129,16 @@ contract Parameters is ACL, Constants, IParameters {
         return (state);
     }
 
-    function getAllSlashParams() external view override returns (uint16,uint16,uint16, uint16)
+    function getAllSlashParams()
+        external
+        view
+        override
+        returns (
+            uint16,
+            uint16,
+            uint16,
+            uint16
+        )
     {
         return (slashNums.bounty, slashNums.burn, slashNums.keep, baseDenominator);
     }

--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -66,7 +66,7 @@ contract RewardManager is Initializable, ACL, Constants, IRewardManager {
         uint256 stakeValue,
         uint32 ageValue
     ) public view returns (uint256, uint32) {
-        uint256 penalty = ((epochs) * (stakeValue * (parameters.penaltyNotRevealNum()))) / parameters.penaltyNotRevealDenom();
+        uint256 penalty = ((epochs) * (stakeValue * (parameters.penaltyNotRevealNum()))) / parameters.baseDenominator();
         uint256 newStake = penalty < stakeValue ? stakeValue - penalty : 0;
         uint32 penaltyAge = epochs * 10000;
         uint32 newAge = penaltyAge < ageValue ? ageValue - penaltyAge : 0;

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -297,7 +297,9 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause, 
         uint256 amountToBeBurned;
         uint256 amountToBeKept;
 
+        // Block Scoping
         // Done for stack too deep issue
+        // https://soliditydeveloper.com/stacktoodeep
         {
             (uint16 bountyNum, uint16 burnSlashNum, uint16 keepSlashNum, uint16 baseDenominator) = parameters.getAllSlashParams();
 

--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -299,12 +299,11 @@ contract StakeManager is Initializable, ACL, StakeStorage, StateManager, Pause, 
 
         // Done for stack too deep issue
         {
-        (uint16 bountyNum, uint16 burnSlashNum, uint16 keepSlashNum, uint16 baseDenominator) =
-        parameters.getAllSlashParams();
+            (uint16 bountyNum, uint16 burnSlashNum, uint16 keepSlashNum, uint16 baseDenominator) = parameters.getAllSlashParams();
 
-        bounty = (_stake * bountyNum) / baseDenominator;
-        amountToBeBurned = (_stake * burnSlashNum) / baseDenominator;
-        amountToBeKept = (_stake * keepSlashNum) / baseDenominator;
+            bounty = (_stake * bountyNum) / baseDenominator;
+            amountToBeBurned = (_stake * burnSlashNum) / baseDenominator;
+            amountToBeKept = (_stake * keepSlashNum) / baseDenominator;
         }
 
         uint256 slashPenaltyAmount = bounty + amountToBeBurned + amountToBeKept;

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -18,25 +18,17 @@ interface IParameters {
 
     function penaltyNotRevealNum() external view returns (uint16);
 
-    function penaltyNotRevealDenom() external view returns (uint16);
-
     function bountyNum() external view returns (uint16);
-
-    function bountyDenom() external view returns (uint16);
 
     function burnSlashNum() external view returns (uint16);
 
-    function burnSlashDenom() external view returns (uint16);
+    function baseDenominator() external view returns (uint16);
 
     function maxCommission() external view returns (uint8);
 
     function withdrawLockPeriod() external view returns (uint8);
 
     function withdrawReleasePeriod() external view returns (uint8);
-
-    function slashPenaltyNum() external view returns (uint16);
-
-    function slashPenaltyDenom() external view returns (uint16);
 
     function escapeHatchEnabled() external view returns (bool);
 

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -6,7 +6,15 @@ interface IParameters {
 
     function getState() external view returns (uint8);
 
-    function getAllSlashParams() external view returns (uint16,uint16,uint16, uint16);
+    function getAllSlashParams()
+        external
+        view
+        returns (
+            uint16,
+            uint16,
+            uint16,
+            uint16
+        );
 
     function epochLength() external view returns (uint16);
 

--- a/contracts/Core/interface/IParameters.sol
+++ b/contracts/Core/interface/IParameters.sol
@@ -6,6 +6,8 @@ interface IParameters {
 
     function getState() external view returns (uint8);
 
+    function getAllSlashParams() external view returns (uint16,uint16,uint16, uint16);
+
     function epochLength() external view returns (uint16);
 
     function minStake() external view returns (uint256);
@@ -17,10 +19,6 @@ interface IParameters {
     function blockReward() external view returns (uint256);
 
     function penaltyNotRevealNum() external view returns (uint16);
-
-    function bountyNum() external view returns (uint16);
-
-    function burnSlashNum() external view returns (uint16);
 
     function baseDenominator() external view returns (uint16);
 

--- a/test/Parameters.js
+++ b/test/Parameters.js
@@ -19,8 +19,6 @@ describe('Parameters contract Tests', async () => {
   const expectedRevertMessage = 'AccessControl';
 
   const penaltyNotRevealNumerator = toBigNumber('1');
-  const bountyNumerator = toBigNumber('500');
-  const burnSlashNumerator = toBigNumber('9500');
   const baseDenominator = toBigNumber('10000');
 
   const withdrawLockPeriod = toBigNumber('1');
@@ -78,10 +76,7 @@ describe('Parameters contract Tests', async () => {
     let tx = parameters.connect(signers[1]).setPenaltyNotRevealNum(toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
 
-    tx = parameters.connect(signers[1]).setBurnSlashNum(toBigNumber('1'));
-    await assertRevert(tx, expectedRevertMessage);
-
-    tx = parameters.connect(signers[1]).setBountyNum(toBigNumber('1'));
+    tx = parameters.connect(signers[1]).setSlashParams(toBigNumber('1'), toBigNumber('1'), toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
 
     tx = parameters.connect(signers[1]).setBaseDenominator(toBigNumber('1'));
@@ -170,13 +165,11 @@ describe('Parameters contract Tests', async () => {
     const maxCommission = await parameters.maxCommission();
     assertBNEqual(maxCommission, toBigNumber('19'));
 
-    await parameters.setBurnSlashNum(toBigNumber('22'));
-    const burnSlashNum = await parameters.burnSlashNum();
-    assertBNEqual(burnSlashNum, toBigNumber('22'));
-
-    await parameters.setBountyNum(toBigNumber('24'));
-    const bountyNum = await parameters.bountyNum();
-    assertBNEqual(bountyNum, toBigNumber('24'));
+    await parameters.setSlashParams(toBigNumber('22'), toBigNumber('23'), toBigNumber('24'));
+    const slashNums = await parameters.slashNums();
+    assertBNEqual(slashNums.bounty, toBigNumber('22'));
+    assertBNEqual(slashNums.burn, toBigNumber('23'));
+    assertBNEqual(slashNums.keep, toBigNumber('24'));
 
     await parameters.setBaseDenominator(toBigNumber('1'));
     const baseDenom = await parameters.baseDenominator();
@@ -190,11 +183,10 @@ describe('Parameters contract Tests', async () => {
     const penaltyNotRevealNumValue = await parameters.penaltyNotRevealNum();
     assertBNEqual(penaltyNotRevealNumerator, penaltyNotRevealNumValue);
 
-    const bountyNumValue = await parameters.bountyNum();
-    assertBNEqual(bountyNumerator, bountyNumValue);
-
-    const burnSlashNumValue = await parameters.burnSlashNum();
-    assertBNEqual(burnSlashNumerator, burnSlashNumValue);
+    const slashParams = await parameters.getAllSlashParams();
+    assertBNEqual(slashParams[0], toBigNumber('500'));
+    assertBNEqual(slashParams[1], toBigNumber('9500'));
+    assertBNEqual(slashParams[2], toBigNumber('0'));
 
     const baseDenom = await parameters.baseDenominator();
     assertBNEqual(baseDenom, baseDenominator);

--- a/test/Parameters.js
+++ b/test/Parameters.js
@@ -19,13 +19,9 @@ describe('Parameters contract Tests', async () => {
   const expectedRevertMessage = 'AccessControl';
 
   const penaltyNotRevealNumerator = toBigNumber('1');
-  const penaltyNotRevealDenominator = toBigNumber('10000');
-  const slashPenaltyNumerator = toBigNumber('10000');
-  const slashPenaltyDenominator = toBigNumber('10000');
   const bountyNumerator = toBigNumber('500');
-  const bountyDenominator = toBigNumber('10000');
-  const burnSlashNumerator = toBigNumber('10000');
-  const burnSlashDenominator = toBigNumber('10000');
+  const burnSlashNumerator = toBigNumber('9500');
+  const baseDenominator = toBigNumber('10000');
 
   const withdrawLockPeriod = toBigNumber('1');
   const maxAltBlocks = toBigNumber('5');
@@ -82,25 +78,13 @@ describe('Parameters contract Tests', async () => {
     let tx = parameters.connect(signers[1]).setPenaltyNotRevealNum(toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
 
-    tx = parameters.connect(signers[1]).setPenaltyNotRevealDeom(toBigNumber('1'));
-    await assertRevert(tx, expectedRevertMessage);
-
-    tx = parameters.connect(signers[1]).setSlashPenaltyNum(toBigNumber('1'));
-    await assertRevert(tx, expectedRevertMessage);
-
-    tx = parameters.connect(signers[1]).setSlashPenaltyDenom(toBigNumber('1'));
-    await assertRevert(tx, expectedRevertMessage);
-
     tx = parameters.connect(signers[1]).setBurnSlashNum(toBigNumber('1'));
-    await assertRevert(tx, expectedRevertMessage);
-
-    tx = parameters.connect(signers[1]).setBurnSlashDenom(toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
 
     tx = parameters.connect(signers[1]).setBountyNum(toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
 
-    tx = parameters.connect(signers[1]).setBountyDenom(toBigNumber('1'));
+    tx = parameters.connect(signers[1]).setBaseDenominator(toBigNumber('1'));
     await assertRevert(tx, expectedRevertMessage);
 
     tx = parameters.connect(signers[1]).setWithdrawLockPeriod(toBigNumber('1'));
@@ -141,10 +125,6 @@ describe('Parameters contract Tests', async () => {
     await parameters.setPenaltyNotRevealNum(toBigNumber('5'));
     const penaltyNotRevealNum = await parameters.penaltyNotRevealNum();
     assertBNEqual(penaltyNotRevealNum, toBigNumber('5'));
-
-    await parameters.setPenaltyNotRevealDeom(toBigNumber('6'));
-    const penaltyNotRevealDenom = await parameters.penaltyNotRevealDenom();
-    assertBNEqual(penaltyNotRevealDenom, toBigNumber('6'));
 
     await parameters.setMinStake(toBigNumber('8'));
     const minStake = await parameters.minStake();
@@ -190,29 +170,17 @@ describe('Parameters contract Tests', async () => {
     const maxCommission = await parameters.maxCommission();
     assertBNEqual(maxCommission, toBigNumber('19'));
 
-    await parameters.setSlashPenaltyNum(toBigNumber('20'));
-    const slashPenaltyNum = await parameters.slashPenaltyNum();
-    assertBNEqual(slashPenaltyNum, toBigNumber('20'));
-
-    await parameters.setSlashPenaltyDenom(toBigNumber('21'));
-    const slashPenaltyDenom = await parameters.slashPenaltyDenom();
-    assertBNEqual(slashPenaltyDenom, toBigNumber('21'));
-
     await parameters.setBurnSlashNum(toBigNumber('22'));
     const burnSlashNum = await parameters.burnSlashNum();
     assertBNEqual(burnSlashNum, toBigNumber('22'));
-
-    await parameters.setBurnSlashDenom(toBigNumber('23'));
-    const burnSlashDenom = await parameters.burnSlashDenom();
-    assertBNEqual(burnSlashDenom, toBigNumber('23'));
 
     await parameters.setBountyNum(toBigNumber('24'));
     const bountyNum = await parameters.bountyNum();
     assertBNEqual(bountyNum, toBigNumber('24'));
 
-    await parameters.setBountyDenom(toBigNumber('25'));
-    const bountyDenom = await parameters.bountyDenom();
-    assertBNEqual(bountyDenom, toBigNumber('25'));
+    await parameters.setBaseDenominator(toBigNumber('1'));
+    const baseDenom = await parameters.baseDenominator();
+    assertBNEqual(baseDenom, toBigNumber('1'));
 
     const tx = parameters.setMaxCommission(toBigNumber('101'));
     assertRevert(tx, 'Invalid Max Commission Update');
@@ -222,26 +190,14 @@ describe('Parameters contract Tests', async () => {
     const penaltyNotRevealNumValue = await parameters.penaltyNotRevealNum();
     assertBNEqual(penaltyNotRevealNumerator, penaltyNotRevealNumValue);
 
-    const penaltyNotRevealDenomValue = await parameters.penaltyNotRevealDenom();
-    assertBNEqual(penaltyNotRevealDenominator, penaltyNotRevealDenomValue);
-
-    const slashPenaltyNumValue = await parameters.slashPenaltyNum();
-    assertBNEqual(slashPenaltyNumerator, slashPenaltyNumValue);
-
-    const slashPenaltyDenomValue = await parameters.slashPenaltyDenom();
-    assertBNEqual(slashPenaltyDenominator, slashPenaltyDenomValue);
-
     const bountyNumValue = await parameters.bountyNum();
     assertBNEqual(bountyNumerator, bountyNumValue);
-
-    const bountyDenomValue = await parameters.bountyDenom();
-    assertBNEqual(bountyDenominator, bountyDenomValue);
 
     const burnSlashNumValue = await parameters.burnSlashNum();
     assertBNEqual(burnSlashNumerator, burnSlashNumValue);
 
-    const burnSlashDenomValue = await parameters.burnSlashDenom();
-    assertBNEqual(burnSlashDenominator, burnSlashDenomValue);
+    const baseDenom = await parameters.baseDenominator();
+    assertBNEqual(baseDenom, baseDenominator);
 
     const minStakeValue = await parameters.minStake();
     assertBNEqual(minimumStake, minStakeValue);

--- a/test/StakeManager.js
+++ b/test/StakeManager.js
@@ -347,10 +347,13 @@ describe('StakeManager', function () {
       assertBNEqual(stakeAfterAcc1, stakeBeforeAcc1.add(stake), 'Stake did not increase on staking after withdraw');
 
       await stakeManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-      await parameters.setSlashPenaltyNum(5000); // slashing only half stake
+      await parameters.setBurnSlashNum(4500); // slashing only half stake
       await stakeManager.slash(epoch, stakerIdAcc1, signers[10].address); // slashing signers[1]
 
-      const slashPenaltyAmount = (stakeAfterAcc1.mul((await parameters.slashPenaltyNum()))).div(await parameters.slashPenaltyDenom());
+      const amountToBeBurned = stakeAfterAcc1.mul(await parameters.burnSlashNum()).div(await parameters.baseDenominator());
+      const bounty = stakeAfterAcc1.mul(await parameters.bountyNum()).div(await parameters.baseDenominator());
+      const slashPenaltyAmount = amountToBeBurned.add(bounty);
+
       let staker = await stakeManager.getStaker(stakerIdAcc1);
       const stakeAfterSlash = staker.stake;
       assertBNEqual(stakeAfterSlash, stakeAfterAcc1.sub(slashPenaltyAmount), 'Stake should be less by slashPenalty');
@@ -1043,7 +1046,7 @@ describe('StakeManager', function () {
       await razor.connect(signers[7]).approve(stakeManager.address, stake1);
       await stakeManager.connect(signers[7]).stake(epoch, stake1);
       const stakerIdAcc7 = await stakeManager.stakerIds(signers[7].address);
-      await parameters.setSlashPenaltyNum(10000);
+      await parameters.setBurnSlashNum(9500);
       await stakeManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
       await stakeManager.slash(epoch, stakerIdAcc7, signers[10].address); // slashing whole stake of signers[7]
       const stake2 = tokenAmount('20000');

--- a/test/VoteManager.js
+++ b/test/VoteManager.js
@@ -357,14 +357,21 @@ describe('VoteManager', function () {
         const stakeBeforeAcc4 = (await stakeManager.stakers(stakerIdAcc4)).stake;
 
         const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
-        await parameters.setBurnSlashNum(4500);
+        await parameters.setSlashParams(500, 4500, 0);
         await voteManager.connect(signers[10]).snitch(epoch, votes,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
           signers[4].address);
 
-        const amountToBeBurned = stakeBeforeAcc4.mul(await parameters.burnSlashNum()).div(await parameters.baseDenominator());
-        const bounty = stakeBeforeAcc4.mul(await parameters.bountyNum()).div(await parameters.baseDenominator());
-        const slashPenaltyAmount = amountToBeBurned.add(bounty);
+        const slashNums = await parameters.getAllSlashParams();
+        const bountySlashNum = slashNums[0];
+        const burnSlashNum = slashNums[1];
+        const keepSlashNum = slashNums[2];
+        const baseDeno = slashNums[3];
+        const amountToBeBurned = stakeBeforeAcc4.mul(burnSlashNum).div(baseDeno);
+        const bounty = stakeBeforeAcc4.mul(bountySlashNum).div(baseDeno);
+        const amountTobeKept = stakeBeforeAcc4.mul(keepSlashNum).div(baseDeno);
+        const slashPenaltyAmount = amountToBeBurned.add(bounty).add(amountTobeKept);
+
         assertBNEqual((await stakeManager.stakers(stakerIdAcc4)).stake, stakeBeforeAcc4.sub(slashPenaltyAmount), 'stake should be less by slashPenalty');
         assertBNEqual(bounty, slashPenaltyAmount.div(toBigNumber('10'))); // To check if contract calculation is working as expected
         // Bounty should be locked
@@ -382,7 +389,7 @@ describe('VoteManager', function () {
         const tx = voteManager.connect(signers[10]).snitch(epoch, votes,
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
           signers[4].address);
-        await parameters.setBurnSlashNum(9500); // Restoring the slashPenaltyNum again
+        await parameters.setSlashParams(500, 9500, 0);// Restoring the slashPenaltyNum again
         await assertRevert(tx, 'incorrect secret/value');
       });
 
@@ -482,7 +489,7 @@ describe('VoteManager', function () {
         const stakerId = await stakeManager.stakerIds(signers[7].address);
         // slashing the staker to make his stake below minstake
         await stakeManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-        await parameters.setBurnSlashNum(4500);
+        await parameters.setSlashParams(500, 4500, 0);
         await stakeManager.slash(epoch, stakerId, signers[11].address);
 
         const votes = [100, 200, 300, 400, 500, 600, 700, 800, 900];
@@ -607,7 +614,7 @@ describe('VoteManager', function () {
         await voteManager.connect(signers[7]).commit(epoch, commitment1);
 
         await stakeManager.grantRole(STAKE_MODIFIER_ROLE, signers[0].address);
-        await parameters.setBurnSlashNum(9500);
+        await parameters.setSlashParams(500, 9500, 0);
         await stakeManager.slash(epoch, stakerId, signers[10].address); // slashing signers[7] 100% making his stake zero
 
         await mineToNextState(); // reveal
@@ -670,9 +677,15 @@ describe('VoteManager', function () {
           '0x727d5c9e6d18ed15ce7ac8d3cce6ec8a0e9c02481415c0823ea49d847ccb9ddd',
           signers[5].address);
 
-        const amountToBeBurned = stakeBeforeAcc5.mul(await parameters.burnSlashNum()).div(await parameters.baseDenominator());
-        const bounty = stakeBeforeAcc5.mul(await parameters.bountyNum()).div(await parameters.baseDenominator());
-        const slashPenaltyAmount = amountToBeBurned.add(bounty);
+        const slashNums = await parameters.getAllSlashParams();
+        const bountySlashNum = slashNums[0];
+        const burnSlashNum = slashNums[1];
+        const keepSlashNum = slashNums[2];
+        const baseDeno = slashNums[3];
+        const amountToBeBurned = stakeBeforeAcc5.mul(burnSlashNum).div(baseDeno);
+        const bounty = stakeBeforeAcc5.mul(bountySlashNum).div(baseDeno);
+        const amountTobeKept = stakeBeforeAcc5.mul(keepSlashNum).div(baseDeno);
+        const slashPenaltyAmount = amountToBeBurned.add(bounty).add(amountTobeKept);
 
         const stakeAfterAcc5 = (await stakeManager.stakers(stakerIdAcc5)).stake;
         assertBNEqual(stakeAfterAcc5, stakeBeforeAcc5.sub(slashPenaltyAmount), 'Stake of account 5 should lessen by slashPenaltyAmount');


### PR DESCRIPTION
Fixes #460 
And following slither warning

```
StakeManager.slash(uint32,uint32,address) (contracts/Core/StakeManager.sol#289-316) performs a multiplication on the result of a division:
	-slashPenaltyAmount = (_stake * parameters.slashPenaltyNum()) / parameters.slashPenaltyDenom() (contracts/Core/StakeManager.sol#295)
	-bounty = (slashPenaltyAmount * parameters.bountyNum()) / parameters.bountyDenom() (contracts/Core/StakeManager.sol#298)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#divide-before-multiply
. analyzed (66 contracts with 73 detectors), 1 result(s) found
```