### PR TITLE
reset Lock extension

### DIFF
--- a/test/StakeManager.js
+++ b/test/StakeManager.js
@@ -1413,7 +1413,6 @@ describe('StakeManager', function () {
     it('staker should be able to increase stake by any number of RZR token', async () => {
       let staker = await stakeManager.getStaker(4);
       const epoch = await getEpoch();
-      console.log(Number(staker.stake));
       const amount = tokenAmount('1');
       const prevStake = staker.stake;
       await razor.connect(signers[4]).approve(stakeManager.address, amount);


### PR DESCRIPTION
Now staker can only reset Lock or withdraw the amount. On reset Lock, Staker/Delegator wont get stake back but lock will be extended so if the miss withdraw release period they could get some more time to withdraw. fixes #445 