### PR TITLE
Rename VotingPenalty to VotingRewardOrPenalty

### DIFF
--- a/contracts/Core/RewardManager.sol
+++ b/contracts/Core/RewardManager.sol
@@ -140,7 +140,7 @@ contract RewardManager is Initializable, Constants, RewardManagerParams, IReward
 
         age = penalty > age ? 0 : age - uint32(penalty);
 
-        stakeManager.setStakerAge(epoch, thisStaker.id, uint32(age), AgeChanged.VotingPenalty);
+        stakeManager.setStakerAge(epoch, thisStaker.id, uint32(age), AgeChanged.VotingRewardOrPenalty);
     }
 
     /// @notice Calculates the stake and age inactivity penalties of the staker

--- a/contracts/Core/storage/Constants.sol
+++ b/contracts/Core/storage/Constants.sol
@@ -19,7 +19,7 @@ contract Constants {
 
     enum AgeChanged {
         InactivityPenalty,
-        VotingPenalty
+        VotingRewardOrPenalty
     }
 
     uint8 public constant NUM_STATES = 5;


### PR DESCRIPTION
Fixes #631 
Renamed VotingPenalty to VotingRewardOrPenalty.

Now for increase or decrease of age in both the cases 'VotingRewardOrPenalty' as a reason will be emitted in event. 