### PR TITLE
fix: fixed scenarios

### DIFF
--- a/scenarios/scenarios.js
+++ b/scenarios/scenarios.js
@@ -78,7 +78,7 @@ describe('Scenarios', async () => {
     }
 
     while (Number(await getState()) !== 4) {
-      if (await getState() === -1) {
+      if (Number(await getState()) === -1) {
         await mineBlock();
       } else {
         await mineToNextState();

--- a/scenarios/scenarios.js
+++ b/scenarios/scenarios.js
@@ -78,10 +78,9 @@ describe('Scenarios', async () => {
     }
 
     while (Number(await getState()) !== 4) {
-      if(await getState()=== -1){
+      if (await getState() === -1) {
         await mineBlock();
-      }
-      else{
+      } else {
         await mineToNextState();
       }
     }

--- a/scenarios/scenarios.js
+++ b/scenarios/scenarios.js
@@ -1,6 +1,7 @@
 const {
   getState, adhocCommit, adhocReveal, getData, adhocPropose,
 } = require('../test/helpers/utils');
+const { mineBlock } = require('../test/helpers/testHelpers');
 const {
   COLLECTION_MODIFIER_ROLE,
   GRACE_PERIOD,
@@ -72,12 +73,17 @@ describe('Scenarios', async () => {
     let i = 0;
     while (i < 9) {
       name = `test${i}`;
+      console.log('job created')
       await collectionManager.createJob(weight, power, selectorType, name, selector, url);
       i++;
     }
-
+    console.log("before while", Number(await getState()))
     while (Number(await getState()) !== 4) {
-      if (Number(await getState()) !== -1) {
+      if(await getState()=== -1){
+        console.log("after if", Number(await getState()))
+        await mineBlock();
+      }
+      else{
         await mineToNextState();
       }
     }

--- a/scenarios/scenarios.js
+++ b/scenarios/scenarios.js
@@ -73,14 +73,12 @@ describe('Scenarios', async () => {
     let i = 0;
     while (i < 9) {
       name = `test${i}`;
-      console.log('job created')
       await collectionManager.createJob(weight, power, selectorType, name, selector, url);
       i++;
     }
-    console.log("before while", Number(await getState()))
+
     while (Number(await getState()) !== 4) {
       if(await getState()=== -1){
-        console.log("after if", Number(await getState()))
         await mineBlock();
       }
       else{

--- a/test/AssignCollectionsRandomly.js
+++ b/test/AssignCollectionsRandomly.js
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-destructuring */
 const { expect } = require('chai');
 const { network } = require('hardhat');
+const { mineBlock } = require('./helpers/testHelpers');
 const {
   assertBNEqual,
   mineToNextEpoch,
@@ -79,10 +80,9 @@ describe('AssignCollectionsRandomly', function () {
         i++;
       }
       while (Number(await getState()) !== 4) {
-        if(await getState()=== -1){
+        if (await getState() === -1) {
           await mineBlock();
-        }
-        else{
+        } else {
           await mineToNextState();
         }
       }

--- a/test/AssignCollectionsRandomly.js
+++ b/test/AssignCollectionsRandomly.js
@@ -79,7 +79,10 @@ describe('AssignCollectionsRandomly', function () {
         i++;
       }
       while (Number(await getState()) !== 4) {
-        if (Number(await getState()) !== -1) {
+        if(await getState()=== -1){
+          await mineBlock();
+        }
+        else{
           await mineToNextState();
         }
       }

--- a/test/AssignCollectionsRandomly.js
+++ b/test/AssignCollectionsRandomly.js
@@ -80,7 +80,7 @@ describe('AssignCollectionsRandomly', function () {
         i++;
       }
       while (Number(await getState()) !== 4) {
-        if (await getState() === -1) {
+        if (Number(await getState()) === -1) {
           await mineBlock();
         } else {
           await mineToNextState();

--- a/test/helpers/testHelpers.js
+++ b/test/helpers/testHelpers.js
@@ -166,6 +166,7 @@ module.exports = {
   assertBNNotEqual,
   waitNBlocks,
   mineAdvance,
+  mineBlock,
   mineToNextEpoch,
   mineToNextState,
   takeSnapshot,

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -166,7 +166,7 @@ const getState = async () => {
   const lowerLimit = 5;
   const upperLimit = EPOCH_LENGTH.div(NUM_STATES) - 5;
   if (timestamp % (EPOCH_LENGTH.div(NUM_STATES)) > upperLimit || timestamp % (EPOCH_LENGTH.div(NUM_STATES)) < lowerLimit) {
-    return -1
+    return -1;
   } else {
     return state.mod(NUM_STATES).toNumber();
   }

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -166,7 +166,7 @@ const getState = async () => {
   const lowerLimit = 5;
   const upperLimit = EPOCH_LENGTH.div(NUM_STATES) - 5;
   if (timestamp % (EPOCH_LENGTH.div(NUM_STATES)) > upperLimit || timestamp % (EPOCH_LENGTH.div(NUM_STATES)) < lowerLimit) {
-    return -1;
+    return -1
   } else {
     return state.mod(NUM_STATES).toNumber();
   }


### PR DESCRIPTION
while its in buffer state it was returning -1
now here we cant do mineToNextState because its just a buffer state we need to wait till it it reaches to the window where we can vote
`while (Number(await getState()) !== 4) {
      if (Number(await getState()) !== -1) {
        await mineToNextState();
      }
    } `

so as per the current code if state == -1 we do nothing
This was causing while loop to go in infinte loop because everytime in getState we were calculating block timestamp based on the same block number since nothing was getting mined

` while (Number(await getState()) !== 4) {
        if(await getState()=== -1){
          await mineBlock();
        }
        else{
          await mineToNextState();
        }
      } `
so I modified this method, that if state is -1 , we mine block, so that getState could come out of buffer state and transaction could happen.