### PR TITLE
chore: slither warnings

### DIFF
--- a/contracts/Core/StakeManager.sol
+++ b/contracts/Core/StakeManager.sol
@@ -520,8 +520,7 @@ contract StakeManager is Initializable, StakeStorage, StateManager, Pause, Stake
         //the following transfers are not `reuquire`d. even if the transfers fail, the slashing
         //tx should complete.
         // Ignoring below line for testing as this is standard erc20 function
-        // slither-disable-next-line unchecked-transfer
-        razor.transfer(BURN_ADDRESS, amountToBeBurned);
+        require(razor.transfer(BURN_ADDRESS, amountToBeBurned), "couldn't burn");
     }
 
     /**

--- a/contracts/Core/parameters/Governance.sol
+++ b/contracts/Core/parameters/Governance.sol
@@ -240,8 +240,7 @@ contract Governance is Initializable, ACL, Constants {
      * @param _maxTolerance updated value for maxTolerance
      */
     function setMaxTolerance(uint32 _maxTolerance) external onlyRole(GOVERNER_ROLE) {
-        // slither-disable-next-line too-many-digits
-        require(_maxTolerance <= BASE_DENOMINATOR, "maxTolerance exceeds 10000000");
+        require(_maxTolerance <= BASE_DENOMINATOR, "maxTolerance exceeds 10_000_000");
         emit ParameterChanged(msg.sender, "maxTolerance", _maxTolerance, block.timestamp);
         collectionManagerParams.setMaxTolerance(_maxTolerance);
         rewardManagerParams.setMaxTolerance(_maxTolerance);

--- a/contracts/Core/parameters/child/CollectionManagerParams.sol
+++ b/contracts/Core/parameters/child/CollectionManagerParams.sol
@@ -7,8 +7,7 @@ import "../../storage/Constants.sol";
 abstract contract CollectionManagerParams is ACL, ICollectionManagerParams, Constants {
     uint8 public buffer = 5;
     /// @notice maximum percentage deviation allowed from medians for all collections
-    // slither-disable-next-line too-many-digits
-    uint32 public maxTolerance = 1000000;
+    uint32 public maxTolerance = 1_000_000;
 
     /// @inheritdoc ICollectionManagerParams
     function setMaxTolerance(uint32 _maxTolerance) external override onlyRole(GOVERNANCE_ROLE) {

--- a/contracts/Core/parameters/child/RewardManagerParams.sol
+++ b/contracts/Core/parameters/child/RewardManagerParams.sol
@@ -17,8 +17,7 @@ abstract contract RewardManagerParams is ACL, IRewardManagerParams, Constants {
     /// @notice reward given to staker whose block is confirmed
     uint256 public blockReward = 100 * (10**18);
     /// @notice maximum percentage deviation allowed from medians for all collections
-    // slither-disable-next-line too-many-digits
-    uint32 public maxTolerance = 1000000;
+    uint32 public maxTolerance = 1_000_000;
 
     /// @inheritdoc IRewardManagerParams
     function setPenaltyNotRevealNum(uint32 _penaltyNotRevealNumerator) external override onlyRole(GOVERNANCE_ROLE) {

--- a/contracts/Core/parameters/child/StakeManagerParams.sol
+++ b/contracts/Core/parameters/child/StakeManagerParams.sol
@@ -40,8 +40,7 @@ abstract contract StakeManagerParams is ACL, IStakeManagerParams, Constants {
     /// @notice the number of epochs for which a staker cant change commission once set/change
     uint16 public epochLimitForUpdateCommission = 100;
     /// @notice slashing params being used if staker is slashed. Slash Penalty = bounty + burned + kept == 100%
-    // slither-disable-next-line too-many-digits
-    SlashNums public slashNums = SlashNums(500000, 9500000, 0);
+    SlashNums public slashNums = SlashNums(500_000, 9_500_000, 0);
     /// @notice minimum amount of stake required to participate
     uint256 public minStake = 20000 * (10**18);
     /// @notice minimum amount of stake required to become a staker

--- a/contracts/Core/storage/Constants.sol
+++ b/contracts/Core/storage/Constants.sol
@@ -28,8 +28,7 @@ contract Constants {
     uint16 public constant EPOCH_LENGTH = 1800;
 
     address public constant BURN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    // slither-disable-next-line too-many-digits
-    uint32 public constant BASE_DENOMINATOR = 10000000;
+    uint32 public constant BASE_DENOMINATOR = 10_000_000;
     // keccak256("BLOCK_CONFIRMER_ROLE")
     bytes32 public constant BLOCK_CONFIRMER_ROLE = 0x18797bc7973e1dadee1895be2f1003818e30eae3b0e7a01eb9b2e66f3ea2771f;
 

--- a/test/Governance.js
+++ b/test/Governance.js
@@ -195,7 +195,7 @@ describe('Governance contract Test', async () => {
     await assertRevert(tx, 'Slash nums addtion exceeds 10mil');
 
     tx = governance.setMaxTolerance(toBigNumber('11000000'));
-    await assertRevert(tx, 'maxTolerance exceeds 10000000');
+    await assertRevert(tx, 'maxTolerance exceeds 10_000_000');
 
     await governance.connect(signers[0]).setToAssign(toBigNumber('10'));
     const toAssign = await voteManager.toAssign();


### PR DESCRIPTION
fixes #748 

Done 
```
too many digits
require on trasnfer
```
NA 
```
costable states : 
slither is not asking to assign value only, then want to define it CONSTANT
```
https://github.com/crytic/slither/wiki/Detector-Documentation#state-variables-that-could-be-declared-constant

```
reeent no eth check 
we deducted its meaning incorrect last time, it doesn't say that eth is involved, its contrary
```
https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-1