### PR TITLE
fix: increase network timeout

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -89,6 +89,7 @@ module.exports = {
       url: PROVIDER_URL || '',
       accounts: { mnemonic: MNEMONIC },
       chainId: ENV_CHAIN_IDS[NETWORK],
+      timeout: 60000,
     },
   },
   etherscan: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -84,12 +84,13 @@ module.exports = {
       url: PROVIDER_URL || '',
       accounts: { mnemonic: MNEMONIC },
       chainId: ENV_CHAIN_IDS[NETWORK],
+      timeout: 300000,
     },
     skale: {
       url: PROVIDER_URL || '',
       accounts: { mnemonic: MNEMONIC },
       chainId: ENV_CHAIN_IDS[NETWORK],
-      timeout: 60000,
+      timeout: 300000,
     },
   },
   etherscan: {


### PR DESCRIPTION
Deployment can fail due to timeout error. This can happen if the RPC takes longer than 20 seconds(default) to respond. To fix this issue I have override the default timeout config for skale to 60 seconds.

fixes #819 