### PR TITLE
fix: reinstall npm packages when checking out to master circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: large
     steps:
       - attach_workspace:
@@ -47,13 +47,13 @@ jobs:
       - run:
           name: Run tests
           command: |
-            CI=true npm run test 
+            CI=true npm run test
       - store_artifacts:
           path: test
           prefix: test
   scenarios:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: large
     steps:
       - attach_workspace:
@@ -66,10 +66,9 @@ jobs:
           path: scenarios
           prefix: scenarios
 
-
   lint:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: medium
     steps:
       - attach_workspace:
@@ -81,10 +80,9 @@ jobs:
           path: lint
           prefix: lint
 
-
   coverage:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     # parallelism: 10
     resource_class: xlarge
     steps:
@@ -100,19 +98,19 @@ jobs:
 
   slither:
     docker:
-      - image: 'trailofbits/eth-security-toolbox'
+      - image: "trailofbits/eth-security-toolbox"
     resource_class: medium
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Slither
-          command: | 
-              slither . --filter-paths "node_modules" --disable-color
-              
+          command: |
+            slither . --filter-paths "node_modules" --disable-color
+
   gasCompare:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: medium
     steps:
       - attach_workspace:
@@ -120,18 +118,17 @@ jobs:
       - run:
           name: Run GasCompare
           command: |
-              if [ "$CIRCLE_BRANCH" == 'master' ]; then
-              exit 0
-              fi
-              CI=true npm run test
-              mv ./gasReporterOutput.json /tmp/gasReporterOutput_Current.json
-              git checkout master
-              CI=true npm run test
-              mv ./gasReporterOutput.json /tmp/gasReporterOutput_Master.json
-              git checkout $CIRCLE_BRANCH
-              npm run gasCompare /tmp/gasReporterOutput_Current.json /tmp/gasReporterOutput_Master.json
-              
-
+            if [ "$CIRCLE_BRANCH" == 'master' ]; then
+            exit 0
+            fi
+            CI=true npm run test
+            mv ./gasReporterOutput.json /tmp/gasReporterOutput_Current.json
+            git checkout master
+            npm install
+            CI=true npm run test
+            mv ./gasReporterOutput.json /tmp/gasReporterOutput_Master.json
+            git checkout $CIRCLE_BRANCH
+            npm run gasCompare /tmp/gasReporterOutput_Current.json /tmp/gasReporterOutput_Master.json
 
 notify:
   webhooks:
@@ -149,16 +146,16 @@ workflows:
             - install_dependencies
       - scenarios:
           requires:
-          - install_dependencies
+            - install_dependencies
       - coverage:
           requires:
-          - install_dependencies
+            - install_dependencies
       - slither:
           requires:
-          - install_dependencies
+            - install_dependencies
       - lint:
           requires:
-          - install_dependencies
+            - install_dependencies
       - gasCompare:
           requires:
-          - install_dependencies
+            - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: large
     steps:
       - attach_workspace:
@@ -53,7 +53,7 @@ jobs:
           prefix: test
   scenarios:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: large
     steps:
       - attach_workspace:
@@ -68,7 +68,7 @@ jobs:
 
   lint:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: medium
     steps:
       - attach_workspace:
@@ -82,7 +82,7 @@ jobs:
 
   coverage:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     # parallelism: 10
     resource_class: xlarge
     steps:
@@ -98,7 +98,7 @@ jobs:
 
   slither:
     docker:
-      - image: "trailofbits/eth-security-toolbox"
+      - image: 'trailofbits/eth-security-toolbox'
     resource_class: medium
     steps:
       - attach_workspace:
@@ -110,7 +110,7 @@ jobs:
 
   gasCompare:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: medium
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: large
     steps:
       - attach_workspace:
@@ -53,7 +53,7 @@ jobs:
           prefix: test
   scenarios:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: large
     steps:
       - attach_workspace:
@@ -65,10 +65,10 @@ jobs:
       - store_artifacts:
           path: scenarios
           prefix: scenarios
-z
+
   lint:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: medium
     steps:
       - attach_workspace:
@@ -82,7 +82,7 @@ z
 
   coverage:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     # parallelism: 10
     resource_class: xlarge
     steps:
@@ -98,7 +98,7 @@ z
 
   slither:
     docker:
-      - image: 'trailofbits/eth-security-toolbox'
+      - image: "trailofbits/eth-security-toolbox"
     resource_class: medium
     steps:
       - attach_workspace:
@@ -110,7 +110,7 @@ z
 
   gasCompare:
     docker:
-      - image: 'cimg/node:16.5'
+      - image: "cimg/node:16.5"
     resource_class: medium
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
             npm install
             CI=true npm run test
             mv ./gasReporterOutput.json /tmp/gasReporterOutput_Master.json
+            git reset --hard
             git checkout $CIRCLE_BRANCH
             npm run gasCompare /tmp/gasReporterOutput_Current.json /tmp/gasReporterOutput_Master.json
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: large
     steps:
       - attach_workspace:
@@ -53,7 +53,7 @@ jobs:
           prefix: test
   scenarios:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: large
     steps:
       - attach_workspace:
@@ -65,10 +65,10 @@ jobs:
       - store_artifacts:
           path: scenarios
           prefix: scenarios
-
+z
   lint:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: medium
     steps:
       - attach_workspace:
@@ -82,7 +82,7 @@ jobs:
 
   coverage:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     # parallelism: 10
     resource_class: xlarge
     steps:
@@ -98,7 +98,7 @@ jobs:
 
   slither:
     docker:
-      - image: "trailofbits/eth-security-toolbox"
+      - image: 'trailofbits/eth-security-toolbox'
     resource_class: medium
     steps:
       - attach_workspace:
@@ -110,7 +110,7 @@ jobs:
 
   gasCompare:
     docker:
-      - image: "cimg/node:16.5"
+      - image: 'cimg/node:16.5'
     resource_class: medium
     steps:
       - attach_workspace:


### PR DESCRIPTION
- Master has hardhat-deploy integrated and the current branch (v1-audit-feedback) does not. 

- Steps causing the issue: We install the current branches npm packages, run gasCompare, then checkout to master and run gasCompare again. We now need to reinstall npm packages when checking out to master to make sure missing modules are installed. 